### PR TITLE
ENH: use module level logging

### DIFF
--- a/basil/HL/FEI4AdapterCard.py
+++ b/basil/HL/FEI4AdapterCard.py
@@ -15,6 +15,8 @@ import abc
 
 from basil.HL.HardwareLayer import HardwareLayer
 
+logger = logging.getLogger(__name__)
+
 
 class AdcMax1239(HardwareLayer):
     '''ADC MAX1238/MAX1239
@@ -327,9 +329,9 @@ class FEI4AdapterCard(AdcMax1239, DacMax520, Eeprom24Lc128, Fei4Dcs):
         # read calibration
         if not self._init['no_calibration']:
             self.read_eeprom_calibration()
-            logging.info('Found adapter card: {}'.format('%s with ID %s' % ('Single Chip Adapter Card', self.get_id())))
+            logger.info('Found adapter card: {}'.format('%s with ID %s' % ('Single Chip Adapter Card', self.get_id())))
         else:
-            logging.info('FEI4AdapterCard: Skeeping calibration.')
+            logger.info('FEI4AdapterCard: Skeeping calibration.')
 
     def read_eeprom_calibration(self, temperature=False):  # use default values for temperature, EEPROM values are usually not calibrated and random
         '''Reading EEPROM calibration for power regulators and temperature

--- a/basil/HL/FEI4QuadModuleAdapterCard.py
+++ b/basil/HL/FEI4QuadModuleAdapterCard.py
@@ -15,6 +15,8 @@ import string
 from basil.HL.HardwareLayer import HardwareLayer
 from basil.HL.FEI4AdapterCard import AdcMax1239, Eeprom24Lc128, Fei4Dcs
 
+logger = logging.getLogger(__name__)
+
 
 class DacMax5380(HardwareLayer):
     '''DAC MAX5380
@@ -148,7 +150,7 @@ class FEI4QuadModuleAdapterCard(AdcMax1239, DacDs4424, DacMax5380, Eeprom24Lc128
         self._setup_adc(self.SETUP_FLAGS_BI)
         self.read_eeprom_calibration()
         self.set_current_limit('CH1', 1.0)
-        logging.info('Found adapter card: {}'.format('%s with ID %s' % ('Quad Module Adapter Card', self.get_id())))
+        logger.info('Found adapter card: {}'.format('%s with ID %s' % ('Quad Module Adapter Card', self.get_id())))
 
     def read_eeprom_calibration(self, temperature=False):  # use default values for temperature, EEPROM values are usually not calibrated and random
         '''Reading EEPROM calibration for power regulators and temperature

--- a/basil/HL/FadcConf.py
+++ b/basil/HL/FadcConf.py
@@ -7,6 +7,8 @@
 from basil.HL.RegisterHardwareLayer import HardwareLayer
 import logging
 
+logger = logging.getLogger(__name__)
+
 
 class FadcConf(HardwareLayer):
 
@@ -15,7 +17,7 @@ class FadcConf(HardwareLayer):
 
     def init(self):
         super(FadcConf, self).init()
-        logging.info("Initializing FADC Configuration...")
+        logger.info("Initializing FADC Configuration...")
 
         self._intf.set_data([0x00, 0x10])  # RESET ADC
         self._intf.start()

--- a/basil/HL/GPAC.py
+++ b/basil/HL/GPAC.py
@@ -15,6 +15,8 @@ import string
 from basil.HL.HardwareLayer import HardwareLayer
 from basil.HL.FEI4AdapterCard import Eeprom24Lc128
 
+logger = logging.getLogger(__name__)
+
 
 class MuxPca9540B(HardwareLayer):
     '''PCA 9540B
@@ -702,9 +704,9 @@ class GPAC(I2cAnalogChannel, I2cEeprom):
         # read calibration
         if not self._init['no_calibration']:
             self.read_eeprom_calibration()
-            logging.info('Found adapter card: {}'.format('%s with ID %s' % ('General Purpose Analog Card', self.get_id())))
+            logger.info('Found adapter card: {}'.format('%s with ID %s' % ('General Purpose Analog Card', self.get_id())))
         else:
-            logging.info('GPAC: Skeeping calibration.')
+            logger.info('GPAC: Skeeping calibration.')
 
         # setup current limit and current source
         self.set_current_limit('PWR0', 0.1)
@@ -882,5 +884,5 @@ class GPAC(I2cAnalogChannel, I2cEeprom):
         # if value is greater than maximum dac value, set it to maximum and output an error message
         if value > 4095:
             value = 4095
-            logging.warning('%s DAC value reached maximum value', channel)
+            logger.warning('%s DAC value reached maximum value', channel)
         I2cAnalogChannel._set_dac_value(self, value=value, **self._ch_map[channel]['DAC'])

--- a/basil/HL/MIO_PLL.py
+++ b/basil/HL/MIO_PLL.py
@@ -9,6 +9,8 @@ import logging
 
 from basil.HL.HardwareLayer import HardwareLayer
 
+logger = logging.getLogger(__name__)
+
 
 class MIO_PLL(HardwareLayer):
     '''
@@ -171,9 +173,9 @@ class MIO_PLL(HardwareLayer):
                                             self.chg_pump = 4;
                         ftest = self.fref * self.p_total / self.q_total * 1 / self.div
                         fvco  = self.fref * self.p_total / self.q_total
-                        logging.info('PLL frequency set to ' + str(ftest) + ' MHz' + ' (VCO @ ' + str(fvco) + ' MHz)')
+                        logger.info('PLL frequency set to ' + str(ftest) + ' MHz' + ' (VCO @ ' + str(fvco) + ' MHz)')
                         return True
-        logging.error('MIO_PLL: Could not find PLL parameters')
+        logger.error('MIO_PLL: Could not find PLL parameters')
         return False
 
     def _updateRegisters(self):

--- a/basil/HL/NTCRegister.py
+++ b/basil/HL/NTCRegister.py
@@ -11,6 +11,8 @@ import math
 
 from basil.HL.RegisterHardwareLayer import HardwareLayer
 
+logger = logging.getLogger(__name__)
+
 
 class NTCRegister(HardwareLayer):
     """ Register class for NTCRegister
@@ -31,7 +33,7 @@ class NTCRegister(HardwareLayer):
         if "NTC_type" not in self._conf:
             self._conf["NTC_type"] = "TDK_NTCG16H"
 
-        logging.debug("Initializing NTC " + self._conf["NTC_type"] + " on channel " + self._conf["arg_add"]["channel"])
+        logger.debug("Initializing NTC " + self._conf["NTC_type"] + " on channel " + self._conf["arg_add"]["channel"])
 
         if self._conf["NTC_type"] == "TDK_NTCG16H":
             self.R_RATIO = np.array([18.85, 14.429, 11.133, 8.656, 6.779, 5.346, 4.245, 3.393, 2.728, 2.207, 1.796, 1.47, 1.209, 1.0, 0.831, 0.694, 0.583, 0.491, 0.416, 0.354, 0.302, 0.259, 0.223, 0.192, 0.167, 0.145, 0.127, 0.111, 0.0975, 0.086, 0.076, 0.0674, 0.0599, 0.0534])
@@ -60,7 +62,7 @@ class NTCRegister(HardwareLayer):
             j = arg[0]
 
         k = 1.0 / (math.log(r_ratio / self.R_RATIO[j]) / self.B_CONST[j] + 1 / self.TEMP[j])[0]
-        logging.info("Temperature (C): %f", k - 273.15)
+        logger.info("Temperature (C): %f", k - 273.15)
 
         if unit == "C":
             return k - 273.15

--- a/basil/HL/RegisterHardwareLayer.py
+++ b/basil/HL/RegisterHardwareLayer.py
@@ -62,7 +62,7 @@ class RegisterHardwareLayer(HardwareLayer):
             version = str(self.VERSION)
         else:
             version = None
-        logger.debug("Initializing %s (firmware version: %s), module %s, base_addr %s" % (self.name, version if 'VERSION' in self._registers else 'n/a', self.__class__.__module__, hex(self._base_addr)))
+        logger.info("Initializing %s (firmware version: %s), module %s, base_addr %s" % (self.name, version if 'VERSION' in self._registers else 'n/a', self.__class__.__module__, hex(self._base_addr)))
         if self._require_version and not eval(version + self._require_version):
             raise Exception("FPGA module %s does not satisfy version requirements (read: %s, require: %s)" % (self.__class__.__module__, version, self._require_version.strip()))
         for reg, value in self._registers.iteritems():

--- a/basil/HL/RegisterHardwareLayer.py
+++ b/basil/HL/RegisterHardwareLayer.py
@@ -14,6 +14,8 @@ from collections import namedtuple
 from basil.utils.BitLogic import BitLogic
 from basil.HL.HardwareLayer import HardwareLayer
 
+logger = logging.getLogger(__name__)
+
 
 # description attributes
 read_only = ['read_only', 'read-only', 'readonly', 'ro']
@@ -60,7 +62,7 @@ class RegisterHardwareLayer(HardwareLayer):
             version = str(self.VERSION)
         else:
             version = None
-        logging.debug("Initializing %s (firmware version: %s), module %s, base_addr %s" % (self.name, version if 'VERSION' in self._registers else 'n/a', self.__class__.__module__, hex(self._base_addr)))
+        logger.debug("Initializing %s (firmware version: %s), module %s, base_addr %s" % (self.name, version if 'VERSION' in self._registers else 'n/a', self.__class__.__module__, hex(self._base_addr)))
         if self._require_version and not eval(version + self._require_version):
             raise Exception("FPGA module %s does not satisfy version requirements (read: %s, require: %s)" % (self.__class__.__module__, version, self._require_version.strip()))
         for reg, value in self._registers.iteritems():
@@ -188,14 +190,14 @@ class RegisterHardwareLayer(HardwareLayer):
             try:
                 return self._get(attribute)
             except Exception, e:
-                logging.error(e)
+                logger.error(e)
                 return None
 
         def setter(self, value):
             try:
                 return self._set(attribute, value)
             except Exception, e:
-                logging.error(e)
+                logger.error(e)
                 return None
         # construct property attribute and add it to the class
         setattr(self.__class__, attribute, property(fget=getter, fset=setter, doc=attribute + ' register'))

--- a/basil/HL/bram_fifo.py
+++ b/basil/HL/bram_fifo.py
@@ -12,6 +12,8 @@ import numpy as np
 
 from basil.HL.RegisterHardwareLayer import RegisterHardwareLayer
 
+logger = logging.getLogger(__name__)
+
 
 class bram_fifo(RegisterHardwareLayer):
     '''BRAM FIFO controller interface for bram_fifo FPGA module.
@@ -67,7 +69,7 @@ class bram_fifo(RegisterHardwareLayer):
         fifo_int_size_2 = self.FIFO_INT_SIZE
         if fifo_int_size_1 > fifo_int_size_2:
             fifo_int_size = fifo_int_size_2  # use smaller chunk
-            logging.warning("Reading wrong FIFO size. Expected: %d <= %d" % (fifo_int_size_1, fifo_int_size_2))
+            logger.warning("Reading wrong FIFO size. Expected: %d <= %d" % (fifo_int_size_1, fifo_int_size_2))
         else:
             fifo_int_size = fifo_int_size_1  # use smaller chunk
         return np.frombuffer(self._intf.read(self._conf['base_data_addr'], size=4 * fifo_int_size), dtype=np.dtype('<u4'))  # size in number of bytes

--- a/basil/HL/iseg_shq.py
+++ b/basil/HL/iseg_shq.py
@@ -11,6 +11,8 @@ from pyiseg import IsegShqCom, status_words
 
 from basil.HL.HardwareLayer import HardwareLayer
 
+logger = logging.getLogger(__name__)
+
 
 class IsegShq(HardwareLayer):
     '''Python interface for ISEG SHQ series
@@ -69,7 +71,7 @@ class IsegShq(HardwareLayer):
         if ramp_speed:
             self.write_v_ramp(self, channel=channel, ramp_speed=ramp_speed)
         self.iseg.write_v_set(channel, raw)
-        logging.info('Ramping voltage...')
+        logger.info('Ramping voltage...')
         self.iseg.write_start_ramp(channel)
         while True:
             status = self.iseg.read_status_word(channel=channel)
@@ -78,9 +80,9 @@ class IsegShq(HardwareLayer):
             elif status == 'ON':
                 break
             else:
-                logging.warning('CH%d: ramping voltage failed with status %s (%s)', channel, status, status_words[status])
+                logger.warning('CH%d: ramping voltage failed with status %s (%s)', channel, status, status_words[status])
                 break
-        logging.info('Finished ramping voltage')
+        logger.info('Finished ramping voltage')
 
     def get_voltage(self, channel, unit='V'):
         raw = self.iseg.read_voltage(channel)
@@ -115,6 +117,6 @@ class IsegShq(HardwareLayer):
             if status == 'ON' or status == 'OFF':
                 break
             if loop_cnt >= 3:
-                logging.warning('CH%d: status %s (%s) after trip reset', channel, status, status_words[status])
+                logger.warning('CH%d: status %s (%s) after trip reset', channel, status, status_words[status])
                 break
             loop_cnt += 1

--- a/basil/HL/mercury.py
+++ b/basil/HL/mercury.py
@@ -4,8 +4,6 @@
 # SiLab, Institute of Physics, University of Bonn
 # ------------------------------------------------------------
 #
-import logging
-
 from basil.HL.RegisterHardwareLayer import HardwareLayer
 
 

--- a/basil/HL/sitcp_fifo.py
+++ b/basil/HL/sitcp_fifo.py
@@ -4,9 +4,6 @@
 # SiLab, Institute of Physics, University of Bonn
 # ------------------------------------------------------------
 #
-
-import logging
-
 import numpy as np
 
 from basil.HL.HardwareLayer import HardwareLayer

--- a/basil/HL/sram_fifo.py
+++ b/basil/HL/sram_fifo.py
@@ -12,6 +12,8 @@ import numpy as np
 
 from basil.HL.RegisterHardwareLayer import RegisterHardwareLayer
 
+logger = logging.getLogger(__name__)
+
 
 class sram_fifo(RegisterHardwareLayer):
     '''SRAM FIFO controller interface for sram_fifo FPGA module.
@@ -46,7 +48,7 @@ class sram_fifo(RegisterHardwareLayer):
         fifo_size : int
             FIFO size in units of bytes (8 bit).
         '''
-        logging.warning("Deprecated: Use get_FIFO_SIZE()")
+        logger.warning("Deprecated: Use get_FIFO_SIZE()")
         return self.FIFO_SIZE
 
     @property
@@ -70,7 +72,7 @@ class sram_fifo(RegisterHardwareLayer):
         fifo_size : int
             FIFO size in units of integers (32 bit).
         '''
-        logging.warning("Deprecated: Use get_FIFO_INT_SIZE()")
+        logger.warning("Deprecated: Use get_FIFO_INT_SIZE()")
         return self.FIFO_INT_SIZE
 
     def get_FIFO_INT_SIZE(self):
@@ -91,7 +93,7 @@ class sram_fifo(RegisterHardwareLayer):
         fifo_size : int
             Read error counter (read attempts when SRAM is empty).
         '''
-        logging.warning("Deprecated: Use get_READ_ERROR_COUNTER()")
+        logger.warning("Deprecated: Use get_READ_ERROR_COUNTER()")
         return self.READ_ERROR_COUNTER
 
     def get_data(self):
@@ -106,7 +108,7 @@ class sram_fifo(RegisterHardwareLayer):
         fifo_int_size_2 = self.FIFO_INT_SIZE
         if fifo_int_size_1 > fifo_int_size_2:
             fifo_int_size = fifo_int_size_2  # use smaller chunk
-            logging.warning("Reading wrong FIFO size. Expected: %d <= %d" % (fifo_int_size_1, fifo_int_size_2))
+            logger.warning("Reading wrong FIFO size. Expected: %d <= %d" % (fifo_int_size_1, fifo_int_size_2))
         else:
             fifo_int_size = fifo_int_size_1  # use smaller chunk
         return np.frombuffer(self._intf.read(self._conf['base_data_addr'], size=4 * fifo_int_size), dtype=np.dtype('<u4'))  # size in number of bytes
@@ -114,5 +116,5 @@ class sram_fifo(RegisterHardwareLayer):
     def get_size(self):
         ''' *Deprecated*
         '''
-        logging.warning("Deprecated: Use get_FIFO_SIZE()")
+        logger.warning("Deprecated: Use get_FIFO_SIZE()")
         return self.FIFO_SIZE

--- a/basil/TL/Dummy.py
+++ b/basil/TL/Dummy.py
@@ -10,6 +10,8 @@ import array
 
 from basil.TL.SiTransferLayer import SiTransferLayer
 
+logger = logging.getLogger(__name__)
+
 
 class Dummy(SiTransferLayer):
     '''Dummy device
@@ -21,7 +23,7 @@ class Dummy(SiTransferLayer):
 
     def init(self):
         super(Dummy, self).init()
-        logging.debug(
+        logger.debug(
             "Dummy SiTransferLayer.init configuration: %s" % str(self._conf))
         if 'mem' in self._init:
             if isinstance(self._init['mem'], dict):
@@ -45,7 +47,7 @@ class Dummy(SiTransferLayer):
         -------
         nothing
         '''
-        logging.debug(
+        logger.debug(
             "Dummy SiTransferLayer.write addr: %s data: %s" % (hex(addr), data))
         for curr_addr, d in enumerate(data, start=addr):
             self.mem[curr_addr] = array.array('B', [d])[0]  # write int
@@ -64,6 +66,6 @@ class Dummy(SiTransferLayer):
         array : array
             Data (byte array) read from memory. Returns 0 for each byte if it hasn't been written to.
         '''
-        logging.debug("Dummy SiTransferLayer.read addr: %s size: %s" %
+        logger.debug("Dummy SiTransferLayer.read addr: %s size: %s" %
                       (hex(addr), size))
         return array.array('B', [self.mem[curr_addr] if curr_addr in self.mem else 0 for curr_addr in range(addr, addr + size)])

--- a/basil/TL/Serial.py
+++ b/basil/TL/Serial.py
@@ -10,6 +10,8 @@ import serial
 
 from basil.TL.TransferLayer import TransferLayer
 
+logger = logging.getLogger(__name__)
+
 
 class Serial(TransferLayer):
     '''Transfer layer of serial device using the pySerial module.
@@ -48,7 +50,7 @@ class Serial(TransferLayer):
 
     def query(self, data):
         if self._port.inWaiting():
-            logging.warning("Found %d bytes in the input buffer of interface %s which will be flushed" % (self._port.inWaiting(), self.name))
+            logger.warning("Found %d bytes in the input buffer of interface %s which will be flushed" % (self._port.inWaiting(), self.name))
             self._port.flushInput()
         self.write(data)
         return self._readline()

--- a/basil/TL/SiSim.py
+++ b/basil/TL/SiSim.py
@@ -16,6 +16,8 @@ from threading import Lock
 from basil.TL.SiTransferLayer import SiTransferLayer
 from basil.utils.sim.Protocol import WriteRequest, ReadRequest, ReadResponse, PickleInterface
 
+logger = logging.getLogger(__name__)
+
 
 class SiSim(SiTransferLayer):
 
@@ -41,7 +43,7 @@ class SiSim(SiTransferLayer):
             try_cnt = self._init['timeout']
 
         while(self._sock.connect_ex((host, port)) != 0):
-            logging.debug("Trying to connect to simulator.")
+            logger.debug("Trying to connect to simulator.")
             time.sleep(1)
             try_cnt -= 1
             if(try_cnt < 1):

--- a/basil/TL/SiTcp.py
+++ b/basil/TL/SiTcp.py
@@ -19,6 +19,8 @@ from threading import RLock as Lock
 
 from basil.TL.SiTransferLayer import SiTransferLayer
 
+logger = logging.getLogger(__name__)
+
 
 class SiTcp(SiTransferLayer):
     '''SiTcp transport layer.
@@ -113,7 +115,7 @@ class SiTcp(SiTransferLayer):
         elif addr == self.BASE_FAKE_FIFO_TCP:
             self.reset_fifo()
         else:
-            logging.warning("SiTcp:write - Invalid address %s" % hex(addr))
+            logger.warning("SiTcp:write - Invalid address %s" % hex(addr))
 
     def _read_single(self, addr, size):
         request = array('B', struct.pack('>BBBBI', self.RBCP_VER, self.RBCP_CMD_RD, self.RBCP_ID, size, addr))
@@ -158,7 +160,7 @@ class SiTcp(SiTransferLayer):
                 return array('B', struct.pack('I', self._get_tcp_data_size()))
             else:
                 return array('B', '\x00' * size)  # FIXME: workaround for SRAM module registers
-#                 logging.warning("SiTcp:read - Invalid address %s" % hex(addr))
+#                 logger.warning("SiTcp:read - Invalid address %s" % hex(addr))
 
     def _tcp_readout(self):
         while True:

--- a/basil/TL/SiUart.py
+++ b/basil/TL/SiUart.py
@@ -14,6 +14,8 @@ import serial
 
 from basil.TL.TransferLayer import TransferLayer
 
+logger = logging.getLogger(__name__)
+
 
 class SiUart(TransferLayer):
     _ser = None
@@ -44,64 +46,64 @@ class SiUart(TransferLayer):
             if not self._ser.isOpen():
                 raise IOError("Port at %s not open" % self._ser.port)
         else:
-            logging.info('Found board')
+            logger.info('Found board')
 
     def __del__(self):
         self._ser.close()
 
     def write(self, addr, data):
-        logging.debug("------------ writing ------------")
-        logging.debug('Addr: %s \tdata: %s', addr, data)
+        logger.debug("------------ writing ------------")
+        logger.debug('Addr: %s \tdata: %s', addr, data)
         done = False
 
         a = array.array('B', 'a') + array.array('B', pack("<I", addr))
         self._ser.write(a)
         if "OK" in self._ser.readall():
-            logging.debug("Addr is okay")
+            logger.debug("Addr is okay")
 
         l = array.array('B', 'l') + array.array('B', pack("<I", len(data)))
         self._ser.write(l)
         if "OK" in self._ser.readall():
-            logging.debug("Length is okay")
+            logger.debug("Length is okay")
 
         w = array.array('B', 'w') + array.array('B', data)
         self._ser.write(w)
         while self._ser.outWaiting() > 0:
-            logging.debug("writing ...")
+            logger.debug("writing ...")
         sleep(0.3)
         if "OK" in self._ser.readall():
             done = True
-            logging.debug("Writing finished")
+            logger.debug("Writing finished")
             return done
 
         raise Exception("Write serial port failed.")
 
     def read(self, addr, size):
-        logging.debug("------------ reading ------------")
-        logging.debug('Addr: %s \tSize: %s', addr, size)
+        logger.debug("------------ reading ------------")
+        logger.debug('Addr: %s \tSize: %s', addr, size)
 
         a = array.array('B', 'a') + array.array('B', pack("<I", addr))
         self._ser.write(a)
         if "OK" in self._ser.readall():
-            logging.debug("Addr is okay")
+            logger.debug("Addr is okay")
 
         l = array.array('B', 'l') + array.array('B', pack("<I", size))
         self._ser.write(l)
         if "OK" in self._ser.readall():
-            logging.debug("Length is okay")
+            logger.debug("Length is okay")
 
         r = array.array('B', 'r')
         self._ser.write(r)
         dataOut = self._ser.read(size)
         while self._ser.inWaiting() > 0:
-            logging.info("reading ...")
+            logger.info("reading ...")
         sleep(0.3)
         if "OK" in self._ser.read():
             a = array.array('B', dataOut)
-            logging.debug("Reading finished")
+            logger.debug("Reading finished")
             return a
         raise Exception("Read serial port failed")
 
     def close(self):
         self._ser.close()
-        logging.debug("_serial _port closed successfully")
+        logger.debug("_serial _port closed successfully")

--- a/basil/TL/SiUsb.py
+++ b/basil/TL/SiUsb.py
@@ -12,6 +12,8 @@ from SiLibUSB import GetUSBBoards, SiUSBDevice
 
 from basil.TL.SiTransferLayer import SiTransferLayer
 
+logger = logging.getLogger(__name__)
+
 
 class SiUsb(SiTransferLayer):
     '''SiLab USB device
@@ -41,13 +43,13 @@ class SiUsb(SiTransferLayer):
             if not devices:
                 raise IOError('Can\'t find USB board. Connect or reset USB board!')
             else:
-                logging.info('Found USB board(s): {}'.format(', '.join(('%s with ID %s (FW %s)' % (device.board_name, filter(type(device.board_id).isdigit, device.board_id), filter(type(device.fw_version).isdigit, device.fw_version))) for device in devices)))
+                logger.info('Found USB board(s): {}'.format(', '.join(('%s with ID %s (FW %s)' % (device.board_name, filter(type(device.board_id).isdigit, device.board_id), filter(type(device.fw_version).isdigit, device.fw_version))) for device in devices)))
                 if len(devices) > 1:
                     raise ValueError('Please specify ID of USB board')
                 self._sidev = devices[0]
         if 'bit_file' in self._init.keys():
             if 'avoid_download' in self._init.keys() and self._init['avoid_download'] is True and self._sidev.XilinxAlreadyLoaded():
-                logging.info("FPGA already programmed, skipping download")
+                logger.info("FPGA already programmed, skipping download")
             else:
                 # invert polarity of the interface clock (IFCONFIG.4) -> IFCLK & UCLK are in-phase
                 ifconfig = self._sidev._Read8051(0xE601, 1)[0]
@@ -60,14 +62,14 @@ class SiUsb(SiTransferLayer):
                     bit_file = os.path.join(os.path.dirname(self.parent.conf_path), self._init['bit_file'])
                 else:
                     raise ValueError('No such bit file: %s' % self._init['bit_file'])
-                logging.info("Programming FPGA: %s..." % (self._init['bit_file']))
+                logger.info("Programming FPGA: %s..." % (self._init['bit_file']))
                 status = self._sidev.DownloadXilinx(bit_file)
-                logging.log(logging.INFO if status else logging.ERROR, 'Success!' if status else 'Failed!')
+                logger.log(logging.INFO if status else logging.ERROR, 'Success!' if status else 'Failed!')
         else:
             if not self._sidev.XilinxAlreadyLoaded():
                 raise ValueError('FPGA not initialized, bit_file not specified')
             else:
-                logging.info("Programming FPGA: bit_file not specified")
+                logger.info("Programming FPGA: bit_file not specified")
 
     def write(self, addr, data):
         if(addr >= self.BASE_ADDRESS_I2C and addr < self.HIGH_ADDRESS_I2C):

--- a/basil/TL/SiUsb3.py
+++ b/basil/TL/SiUsb3.py
@@ -12,6 +12,8 @@ from SiLibUSB import GetUSBBoards, SiUSBDevice
 
 from basil.TL.SiTransferLayer import SiTransferLayer
 
+logger = logging.getLogger(__name__)
+
 
 class SiUsb(SiTransferLayer):
     '''SiLab USB3 device
@@ -41,14 +43,14 @@ class SiUsb(SiTransferLayer):
             if not devices:
                 raise IOError('Can\'t find USB board. Connect or reset USB board!')
             else:
-                logging.info('Found USB board(s): {}'.format(', '.join(('%s with ID %s (FW %s)' % (device.board_name, filter(type(device.board_id).isdigit, device.board_id), filter(type(device.fw_version).isdigit, device.fw_version))) for device in devices)))
+                logger.info('Found USB board(s): {}'.format(', '.join(('%s with ID %s (FW %s)' % (device.board_name, filter(type(device.board_id).isdigit, device.board_id), filter(type(device.fw_version).isdigit, device.fw_version))) for device in devices)))
                 if len(devices) > 1:
                     raise ValueError('Please specify ID of USB board')
                 self._sidev = devices[0]
 # TODO: Firmware upload TBD
 #         if 'bit_file' in self._init.keys():
 #             if 'avoid_download' in self._init.keys() and self._init['avoid_download'] is True and self._sidev.XilinxAlreadyLoaded():
-#                 logging.info("FPGA already programmed, skipping download")
+#                 logger.info("FPGA already programmed, skipping download")
 #             else:
 #                 if os.path.exists(self._init['bit_file']):
 #                     bit_file = self._init['bit_file']
@@ -56,14 +58,14 @@ class SiUsb(SiTransferLayer):
 #                     bit_file = os.path.join(os.path.dirname(self.parent.conf_path), self._init['bit_file'])
 #                 else:
 #                     raise ValueError('No such bit file: %s' % self._init['bit_file'])
-#                 logging.info("Programming FPGA: %s..." % (self._init['bit_file']))
+#                 logger.info("Programming FPGA: %s..." % (self._init['bit_file']))
 #                 status = self._sidev.DownloadXilinx(bit_file)
-#                 logging.log(logging.INFO if status else logging.ERROR, 'Success!' if status else 'Failed!')
+#                 logger.log(logging.INFO if status else logging.ERROR, 'Success!' if status else 'Failed!')
 #         else:
 #             if not self._sidev.XilinxAlreadyLoaded():
 #                 raise ValueError('FPGA not initialized, bit_file not specified')
 #             else:
-#                 logging.info("Programming FPGA: bit_file not specified")
+#                 logger.info("Programming FPGA: bit_file not specified")
 
     def write(self, addr, data):
         if(addr >= self.BASE_ADDRESS_I2C and addr < self.HIGH_ADDRESS_I2C):

--- a/basil/TL/Visa.py
+++ b/basil/TL/Visa.py
@@ -9,6 +9,8 @@ import logging
 
 from basil.TL.TransferLayer import TransferLayer
 
+logger = logging.getLogger(__name__)
+
 
 class Visa(TransferLayer):
     '''Transfer layer for a Virtual Instrument Software Architecture (VISA) provided by pyVisa.
@@ -30,9 +32,9 @@ class Visa(TransferLayer):
         backend = self._init.get('backend', '')  # Empty string means std. backend (NI VISA)
         rm = visa.ResourceManager(backend)
         try:
-            logging.info('BASIL VISA TL with %s backend found the following devices: %s', backend, ", ".join(rm.list_resources()))
+            logger.info('BASIL VISA TL with %s backend found the following devices: %s', backend, ", ".join(rm.list_resources()))
         except NotImplementedError:  # some backends do not always implement the list_resources function
-            logging.info('BASIL VISA TL with %s backend', backend)
+            logger.info('BASIL VISA TL with %s backend', backend)
         self._resource = rm.open_resource(**{key: value for key, value in self._init.items() if key not in ("backend",)})
 
     def close(self):

--- a/basil/dut.py
+++ b/basil/dut.py
@@ -4,8 +4,6 @@
 # SiLab, Institute of Physics, University of Bonn
 # ------------------------------------------------------------
 #
-
-import logging
 import os
 from importlib import import_module
 from inspect import getmembers, isclass
@@ -14,6 +12,12 @@ import sys
 import warnings
 from collections import OrderedDict
 
+# FIXME: Bad practice
+# Logger settings should not be defined in a module, but once by the
+# application developer. Thus outside of basil. Otherwise multiple calls to
+# the basic config are possible. This is left here at the moment for backward
+# compatibility and since our logging format is the same everywhere (?).
+import logging
 logging.basicConfig(level=logging.INFO, format="%(asctime)s - %(name)s - [%(levelname)-8s] (%(threadName)-10s) %(message)s")
 
 

--- a/basil/utils/sim/Test.py
+++ b/basil/utils/sim/Test.py
@@ -17,6 +17,8 @@ from cocotb.triggers import RisingEdge
 from Protocol import WriteRequest, ReadRequest, ReadResponse, PickleInterface
 from cocotb.binary import BinaryValue
 
+logger = logging.getLogger(__name__)
+
 
 def get_bus():
     bus_name_path = os.getenv("SIMULATION_BUS", "basil.utils.sim.BasilBusDriver")
@@ -37,7 +39,7 @@ def socket_test(dut, debug=False):
     port = os.getenv("SIMULATION_PORT", '12345')
 
     if debug:
-        dut._log.setLevel(logging.DEBUG)
+        logger.setLevel(logging.DEBUG)
 
     bus = get_bus()(dut)
 

--- a/basil/utils/sim/Test.py
+++ b/basil/utils/sim/Test.py
@@ -17,8 +17,6 @@ from cocotb.triggers import RisingEdge
 from Protocol import WriteRequest, ReadRequest, ReadResponse, PickleInterface
 from cocotb.binary import BinaryValue
 
-logger = logging.getLogger(__name__)
-
 
 def get_bus():
     bus_name_path = os.getenv("SIMULATION_BUS", "basil.utils.sim.BasilBusDriver")
@@ -39,7 +37,7 @@ def socket_test(dut, debug=False):
     port = os.getenv("SIMULATION_PORT", '12345')
 
     if debug:
-        logger.setLevel(logging.DEBUG)
+        dut._log.setLevel(logging.DEBUG)
 
     bus = get_bus()(dut)
 


### PR DESCRIPTION
Addresses issue #78.

We used just the root logger before for every module in basil.

Detailed example:

When using a laboratory SCPI device one would get such a message:

```bash
2018-01-12 10:05:40,877 - root - [INFO    ] (MainThread) BASIL VISA TL with @sim backend found the following devices
```
`root` stands for the root logger. If one is not interested in messages of this SCPI devices, but one wants to concentrate on the DUT there is no way thus far to change/suppress this info, when using the root logger in the DAQ application. With this PR a module based logger is implemented that allows to fine tune the log per module. The message reads then:

```bash
2018-01-12 10:11:48,293 - basil.TL.Visa - [INFO    ] (MainThread) BASIL VISA TL with @sim backend found the following devices
```

Now it is possible in your application to define the loglevel of this module logger to suppress this info with

```python
import logging
logging.getLogger('basil.TL.Visa').setLevel(logging.WARNING)
```

