### PR TITLE
SiTCP improvements

### DIFF
--- a/basil/HL/sitcp_fifo.py
+++ b/basil/HL/sitcp_fifo.py
@@ -4,6 +4,9 @@
 # SiLab, Institute of Physics, University of Bonn
 # ------------------------------------------------------------
 #
+import struct
+import array
+
 import numpy as np
 
 from basil.HL.HardwareLayer import HardwareLayer
@@ -56,7 +59,7 @@ class sitcp_fifo(HardwareLayer):
             super(sitcp_fifo, self).__setattr__(name, value)
 
     def get_data(self):
-        ''' Reading data from SiTCP FIFO.
+        ''' Reading data from SiTCP FIFO (via TCP).
 
         Returns
         -------
@@ -67,3 +70,14 @@ class sitcp_fifo(HardwareLayer):
         fifo_int_size = (fifo_size - (fifo_size % 4)) / 4
         data = self._intf._get_tcp_data(fifo_int_size * 4)
         return np.frombuffer(data, dtype=np.dtype('<u4'))
+
+    def set_data(self, data):
+        ''' Sending data to via TCP.
+
+        Parameters
+        ----------
+        data : array
+            Array of unsigned integers (32 bit).
+        '''
+        data = array.array('B', struct.unpack("{}B".format(len(data) * 4), struct.pack("{}I".format(len(data)), *data)))
+        self._intf._send_tcp_data(data)

--- a/basil/TL/SiTcp.py
+++ b/basil/TL/SiTcp.py
@@ -236,4 +236,5 @@ class SiTcp(SiTransferLayer):
         self._stop = True
         self._tcp_readout_thread.join()
         self._sock_udp.close()
-        self._sock_tcp.close()
+        if self._init['tcp_connection']:
+            self._sock_tcp.close()

--- a/basil/TL/SiTcp.py
+++ b/basil/TL/SiTcp.py
@@ -163,7 +163,9 @@ class SiTcp(SiTransferLayer):
             elif not wlist:
                 raise IOError('SiTcp:_write_single - Write timeout')
             else:
-                self._sock_udp.send(request)
+                total_sent = self._sock_udp.send(request)
+                if total_sent != len(request):
+                    raise IOError('SiTcp:_write_single - Socket broken')
                 retry_read_cnt = 0
                 while True:
                     retry_read_cnt += 1
@@ -265,7 +267,9 @@ class SiTcp(SiTransferLayer):
             elif not wlist:
                 raise IOError('SiTcp:_read_single - Write timeout')
             else:
-                self._sock_udp.send(request)
+                total_sent = self._sock_udp.send(request)
+                if total_sent != len(request):
+                    raise IOError('SiTcp:_read_single - Socket broken')
                 retry_read_cnt = 0
                 while True:
                     retry_read_cnt += 1

--- a/basil/TL/SiTcp.py
+++ b/basil/TL/SiTcp.py
@@ -227,6 +227,7 @@ class SiTcp(SiTransferLayer):
     def _get_tcp_data(self, size):
         with self._tcp_lock:
             ret_size = min((size, self._get_tcp_data_size()))
+            ret_size = (ret_size - (ret_size % 4))  # modulo 4 bytes
             ret = self._tcp_read_buff[:ret_size]
             self._tcp_read_buff = self._tcp_read_buff[ret_size:]
         return ret

--- a/basil/TL/SiTcp.py
+++ b/basil/TL/SiTcp.py
@@ -371,6 +371,18 @@ class SiTcp(SiTransferLayer):
             self._tcp_read_buff = self._tcp_read_buff[ret_size:]
         return ret
 
+    def _send_tcp_data(self, data):
+        total_sent = 0
+        while not self._stop:
+            _, wlist, _ = select.select([], [self._sock_tcp], [], self._tcp_readout_interval)
+            if wlist:
+                sent = self._sock_tcp.send(data[total_sent:])
+                if sent == 0:
+                    raise IOError('SiTcp:_send_tcp_data - Socket broken')
+                total_sent += sent
+                if total_sent == len(data):
+                    break
+
     def close(self):
         super(SiTcp, self).close()
         self._stop = True

--- a/basil/TL/SiTcp.py
+++ b/basil/TL/SiTcp.py
@@ -15,6 +15,7 @@ import re
 from array import array
 from threading import Thread
 from threading import RLock as Lock
+from time import time
 
 from basil.TL.SiTransferLayer import SiTransferLayer
 
@@ -206,9 +207,11 @@ class SiTcp(SiTransferLayer):
 #                 logger.warning("SiTcp:read - Invalid address %s" % hex(addr))
 
     def _tcp_readout(self):
+        time_read = time()
         while not self._stop:
             try:  # this is in case close() was not called and the thread was forcibly stopped
-                rlist, _, _ = select.select([self._sock_tcp], [], [], self._tcp_readout_interval)
+                rlist, _, _ = select.select([self._sock_tcp], [], [], max(0.0, self._tcp_readout_interval + time_read - time()))
+                time_read = time()
                 if rlist:
                     with self._tcp_lock:
                         data = self._sock_tcp.recv(1024 * 8 * 64)

--- a/examples/mmc3_eth/firmware/src/mmc3_eth.v
+++ b/examples/mmc3_eth/firmware/src/mmc3_eth.v
@@ -338,5 +338,4 @@ always@ (posedge BUS_CLK)
 
 end
 
-
 endmodule

--- a/examples/mmc3_eth/firmware/src/mmc3_eth_core.v
+++ b/examples/mmc3_eth/firmware/src/mmc3_eth_core.v
@@ -1,15 +1,12 @@
-`timescale 1ns / 1ps
-
 /**
  * ------------------------------------------------------------
  * Copyright (c) All rights reserved
  * SiLab, Institute of Physics, University of Bonn
  * ------------------------------------------------------------
  */
-
+`timescale 1ns / 1ps
 
 module mmc3_eth_core(
-
     input wire RESET_N,
 
     // clocks from PLL clock buffers
@@ -30,7 +27,7 @@ module mmc3_eth_core(
     output wire [31:0]  FIFO_DATA,
 
     output wire [7:0]   GPIO
-    );
+);
 
 
 /* -------  MODULE ADREESSES  ------- */
@@ -69,7 +66,5 @@ module mmc3_eth_core(
             fifo_data_out <= 0;
         else if(FIFO_WRITE)
             fifo_data_out <= fifo_data_out + 1;
-            
-     
- 
+
 endmodule

--- a/examples/mmc3_eth/mmc3_eth.py
+++ b/examples/mmc3_eth/mmc3_eth.py
@@ -64,4 +64,4 @@ while time.time() - start_time < testduration:
 chip['CONTROL']['EN'] = 0x0  # stop data source
 chip['CONTROL'].write()
 
-logging.info(str(('Bytes received:', total_len, '  data rate:', round((total_len / 1e6 / testduration), 2), ' Mbit/s')))
+logging.info(str(('Bytes received:', total_len, '  data rate:', round((total_len / 1e6 / testduration), 2), ' Mbits/s')))

--- a/examples/mmc3_eth/mmc3_eth.py
+++ b/examples/mmc3_eth/mmc3_eth.py
@@ -6,37 +6,39 @@
 # SiLab, Institute of Physics, University of Bonn
 # ------------------------------------------------------------
 #
-
+import logging
 import time
-from basil.dut import Dut
+
 import numpy as np
-import logging 
+
+from basil.dut import Dut
+
 
 chip = Dut("mmc3_eth.yaml")
 chip.init()
 
-chip['CONTROL']['EN'] = 0  
+chip['CONTROL']['EN'] = 0
 chip['CONTROL'].write()
 
 logging.info("Starting data test ...")
 
-chip['CONTROL']['EN'] = 1  
+chip['CONTROL']['EN'] = 1
 chip['CONTROL'].write()
 
 start = 0
 for i in range(10):
-    
+
     time.sleep(1)
 
     fifo_data = chip['FIFO'].get_data()
     data_size = len(fifo_data)
-    data_gen = np.linspace(start, data_size-1+start, data_size, dtype=np.int32)
+    data_gen = np.linspace(start, data_size - 1 + start, data_size, dtype=np.int32)
 
     comp = (fifo_data == data_gen)
-    logging.info(str((i, " OK?:", comp.all(), float(32*data_size)/pow(10,6), "Mbit")))
+    logging.info(str((i, " OK?:", comp.all(), float(32 * data_size) / pow(10, 6), "Mbit")))
     start += data_size
 
-chip['CONTROL']['EN'] = 0  #stop data source
+chip['CONTROL']['EN'] = 0  # stop data source
 chip['CONTROL'].write()
 
 logging.info("Starting speed test ...")
@@ -47,21 +49,19 @@ tick = 0
 tick_old = 0
 start_time = time.time()
 
-chip['CONTROL']['EN'] = 1  
+chip['CONTROL']['EN'] = 1
 chip['CONTROL'].write()
 
 while time.time() - start_time < testduration:
     data = chip['FIFO'].get_data()
-    total_len += len(data)*4*8
+    total_len += len(data) * 4 * 8
     time.sleep(0.01)
     tick = int(time.time() - start_time)
     if tick != tick_old:
         logging.info("Time: %f s" % (time.time() - start_time))
         tick_old = tick
 
-chip['CONTROL']['EN'] = 0x0  #stop data source
+chip['CONTROL']['EN'] = 0x0  # stop data source
 chip['CONTROL'].write()
 
-logging.info(str(('Bytes received:', total_len, '  data rate:', round((total_len/1e6/testduration),2), ' Mbit/s')))
-
-
+logging.info(str(('Bytes received:', total_len, '  data rate:', round((total_len / 1e6 / testduration), 2), ' Mbit/s')))

--- a/examples/test_eth/firmware_test_eth/vivado/test_eth.xpr
+++ b/examples/test_eth/firmware_test_eth/vivado/test_eth.xpr
@@ -108,6 +108,13 @@
           <Attr Name="UsedIn" Val="simulation"/>
         </FileInfo>
       </File>
+      <File Path="$PPRDIR/../../../../firmware/modules/utils/fifo_8_to_32.v">
+        <FileInfo>
+          <Attr Name="UsedIn" Val="synthesis"/>
+          <Attr Name="UsedIn" Val="implementation"/>
+          <Attr Name="UsedIn" Val="simulation"/>
+        </FileInfo>
+      </File>
       <File Path="$PPRDIR/../../../../firmware/modules/utils/generic_fifo.v">
         <FileInfo>
           <Attr Name="UsedIn" Val="synthesis"/>

--- a/examples/test_eth/firmware_test_eth/vivado/test_eth.xpr
+++ b/examples/test_eth/firmware_test_eth/vivado/test_eth.xpr
@@ -36,13 +36,13 @@
     <Option Name="WTVcsLaunchSim" Val="0"/>
     <Option Name="WTRivieraLaunchSim" Val="0"/>
     <Option Name="WTActivehdlLaunchSim" Val="0"/>
-    <Option Name="WTXSimExportSim" Val="0"/>
-    <Option Name="WTModelSimExportSim" Val="0"/>
-    <Option Name="WTQuestaExportSim" Val="0"/>
-    <Option Name="WTIesExportSim" Val="0"/>
-    <Option Name="WTVcsExportSim" Val="0"/>
-    <Option Name="WTRivieraExportSim" Val="0"/>
-    <Option Name="WTActivehdlExportSim" Val="0"/>
+    <Option Name="WTXSimExportSim" Val="3"/>
+    <Option Name="WTModelSimExportSim" Val="3"/>
+    <Option Name="WTQuestaExportSim" Val="3"/>
+    <Option Name="WTIesExportSim" Val="3"/>
+    <Option Name="WTVcsExportSim" Val="3"/>
+    <Option Name="WTRivieraExportSim" Val="3"/>
+    <Option Name="WTActivehdlExportSim" Val="3"/>
     <Option Name="GenerateIPUpgradeLog" Val="TRUE"/>
     <Option Name="XSimRadix" Val="hex"/>
     <Option Name="XSimTimeUnit" Val="ns"/>
@@ -122,13 +122,6 @@
           <Attr Name="UsedIn" Val="simulation"/>
         </FileInfo>
       </File>
-      <File Path="$PPRDIR/../../../../firmware/modules/utils/rbcp_to_bus.v">
-        <FileInfo>
-          <Attr Name="UsedIn" Val="synthesis"/>
-          <Attr Name="UsedIn" Val="implementation"/>
-          <Attr Name="UsedIn" Val="simulation"/>
-        </FileInfo>
-      </File>
       <File Path="$PPRDIR/../../../../firmware/modules/utils/rgmii_io.v">
         <FileInfo>
           <Attr Name="UsedIn" Val="synthesis"/>
@@ -137,6 +130,13 @@
         </FileInfo>
       </File>
       <File Path="$PPRDIR/../../../../firmware/modules/rrp_arbiter/rrp_arbiter.v">
+        <FileInfo>
+          <Attr Name="UsedIn" Val="synthesis"/>
+          <Attr Name="UsedIn" Val="implementation"/>
+          <Attr Name="UsedIn" Val="simulation"/>
+        </FileInfo>
+      </File>
+      <File Path="$PPRDIR/../../../../firmware/modules/utils/tcp_to_bus.v">
         <FileInfo>
           <Attr Name="UsedIn" Val="synthesis"/>
           <Attr Name="UsedIn" Val="implementation"/>

--- a/examples/test_eth/firmware_test_eth/vivado/test_eth.xpr
+++ b/examples/test_eth/firmware_test_eth/vivado/test_eth.xpr
@@ -129,6 +129,13 @@
           <Attr Name="UsedIn" Val="simulation"/>
         </FileInfo>
       </File>
+      <File Path="$PPRDIR/../../../../firmware/modules/rrp_arbiter/rrp_arbiter.v">
+        <FileInfo>
+          <Attr Name="UsedIn" Val="synthesis"/>
+          <Attr Name="UsedIn" Val="implementation"/>
+          <Attr Name="UsedIn" Val="simulation"/>
+        </FileInfo>
+      </File>
       <File Path="$PPRDIR/../src/test_eth.v">
         <FileInfo>
           <Attr Name="UsedIn" Val="synthesis"/>
@@ -188,15 +195,16 @@
     </Simulator>
   </Simulators>
   <Runs Version="1" Minor="10">
-    <Run Id="synth_1" Type="Ft3:Synth" SrcSet="sources_1" Part="xc7k160tfbg676-1" ConstrsSet="constrs_1" Description="Vivado Synthesis Defaults" WriteIncrSynthDcp="false" State="current" IncludeInArchive="true">
+    <Run Id="synth_1" Type="Ft3:Synth" SrcSet="sources_1" Part="xc7k160tfbg676-1" ConstrsSet="constrs_1" Description="Vivado Synthesis Defaults" WriteIncrSynthDcp="false" State="current" Dir="$PRUNDIR/synth_1" IncludeInArchive="true">
       <Strategy Version="1" Minor="2">
         <StratHandle Name="Vivado Synthesis Defaults" Flow="Vivado Synthesis 2018"/>
         <Step Id="synth_design"/>
       </Strategy>
+      <GeneratedRun Dir="$PRUNDIR" File="gen_run.xml"/>
       <ReportStrategy Name="Vivado Synthesis Default Reports" Flow="Vivado Synthesis 2018"/>
       <Report Name="ROUTE_DESIGN.REPORT_METHODOLOGY" Enabled="1"/>
     </Run>
-    <Run Id="impl_1" Type="Ft2:EntireDesign" Part="xc7k160tfbg676-1" ConstrsSet="constrs_1" Description="Default settings for Implementation." WriteIncrSynthDcp="false" State="current" SynthRun="synth_1" IncludeInArchive="true">
+    <Run Id="impl_1" Type="Ft2:EntireDesign" Part="xc7k160tfbg676-1" ConstrsSet="constrs_1" Description="Default settings for Implementation." WriteIncrSynthDcp="false" State="current" Dir="$PRUNDIR/impl_1" SynthRun="synth_1" IncludeInArchive="true">
       <Strategy Version="1" Minor="2">
         <StratHandle Name="Vivado Implementation Defaults" Flow="Vivado Implementation 2018"/>
         <Step Id="init_design"/>
@@ -211,6 +219,7 @@
           <Option Id="BinFile">1</Option>
         </Step>
       </Strategy>
+      <GeneratedRun Dir="$PRUNDIR" File="gen_run.xml"/>
       <ReportStrategy Name="Vivado Implementation Default Reports" Flow="Vivado Implementation 2018"/>
       <Report Name="ROUTE_DESIGN.REPORT_METHODOLOGY" Enabled="1"/>
     </Run>

--- a/examples/test_eth/test_eth.py
+++ b/examples/test_eth/test_eth.py
@@ -228,8 +228,6 @@ class Test(object):
         time_read = time.time()
         while not self.stop_thread.wait(max(0.0, self.tcp_readout_delay - time_read + time.time())) or fifo_was_empty < 1:
             time_read = time.time()
-            if self.stop_thread.is_set():
-                self.dut['REGISTERS'].TCP_WRITE_DLY = 0
             try:
                 fifo_data = self.dut['SITCP_FIFO'].get_data()
             except Exception as e:
@@ -240,7 +238,7 @@ class Test(object):
                     self.total_tcp_data_words_read += fifo_data.shape[0]
                     if fifo_data[0] != fifo_data_last_value + 1:
                         logging.warning("TCP not increased by 1 between readouts")
-                        self.total_tcp_err_cnt += (np.abs(fifo_data[0] - fifo_data_last_value + 1))
+                        self.total_tcp_err_cnt += 1
                     err_cnt = np.count_nonzero(np.diff(fifo_data) != 1)
                     if err_cnt:
                         logging.warning("TCP data not increased by 1: errors=%d" % err_cnt)

--- a/examples/test_eth/test_eth.py
+++ b/examples/test_eth/test_eth.py
@@ -148,7 +148,11 @@ class Test(object):
                 logging.info("Total amount transmitted: %.2f GB" % (self.total_tcp_data_words_read * 4 / 10.0**9))
             else:
                 logging.info("Total amount transmitted: %.2f MB" % (self.total_tcp_data_words_read * 4 / 10.0**6))
-            logging.info("Total average TCP read speed: %.2f Mbit/s" % (self.total_tcp_data_words_read * 32 / (self.time_stop - self.time_start) / 10.0**6))
+            total_tcp_avg_read_speed = self.total_tcp_data_words_read * 32 / (self.time_stop - self.time_start) / 10.0**6
+            if total_tcp_avg_read_speed < 1.0:
+                logging.info("Total average TCP read speed: %.2f kbit/s" % (total_tcp_avg_read_speed * 10**3))
+            else:
+                logging.info("Total average TCP read speed: %.2f Mbit/s" % (total_tcp_avg_read_speed))
             if self.tcp_read_speeds:
                 if np.average(self.tcp_read_speeds) < 1.0:
                     logging.info("TCP read speed (min/median/average/max): %.2f/%.2f/%.2f/%.2f kbit/s" % (np.min(self.tcp_read_speeds) * 10**3, np.median(self.tcp_read_speeds) * 10**3, np.average(self.tcp_read_speeds) * 10**3, np.max(self.tcp_read_speeds) * 10**3))
@@ -166,7 +170,11 @@ class Test(object):
                 logging.info("Total amount transmitted: %.2f GB" % (self.total_udp_read_write_cnt * 8 / 10.0**9))
             else:
                 logging.info("Total amount transmitted: %.2f MB" % (self.total_udp_read_write_cnt * 8 / 10.0**6))
-            logging.info("Total average UDP read/write speed: %.2f Mbit/s" % (self.total_udp_read_write_cnt * 64 / (self.time_stop - self.time_start) / 10.0**6))
+            total_udp_avg_read_speed = self.total_udp_read_write_cnt * 64 / (self.time_stop - self.time_start) / 10.0**6
+            if total_udp_avg_read_speed < 1.0:
+                logging.info("Total average UDP read/write speed: %.2f kbit/s" % (total_udp_avg_read_speed * 10**3))
+            else:
+                logging.info("Total average UDP read/write speed: %.2f Mbit/s" % (total_udp_avg_read_speed))
             if self.udp_read_write_speeds:
                 if np.average(self.udp_read_write_speeds) < 1.0:
                     logging.info("UDP read/write speed (min/median/average/max): %.2f/%.2f/%.2f/%.2f kbit/s" % (np.min(self.udp_read_write_speeds) * 10**3, np.median(self.udp_read_write_speeds) * 10**3, np.average(self.udp_read_write_speeds) * 10**3, np.max(self.udp_read_write_speeds) * 10**3))

--- a/examples/test_eth/test_eth.py
+++ b/examples/test_eth/test_eth.py
@@ -53,7 +53,8 @@ class test_eth(RegisterHardwareLayer):
         'UDP_WRITE_CNT': {'descr': {'addr': 10, 'size': 32, 'offset': 0}},
         'TCP_WRITE_DLY': {'default': 0, 'descr': {'addr': 14, 'size': 16, 'offset': 0}},
         'TCP_WRITE_CNT': {'descr': {'addr': 16, 'size': 64, 'offset': 0, 'properties': ['readonly']}},
-        'TCP_FAILED_WRITE_CNT': {'descr': {'addr': 24, 'size': 64, 'offset': 0, 'properties': ['readonly']}}
+        'TCP_FAILED_WRITE_CNT': {'descr': {'addr': 24, 'size': 64, 'offset': 0, 'properties': ['readonly']}},
+        'TCP_RECV_WRITE_CNT': {'descr': {'addr': 32, 'size': 64, 'offset': 0, 'properties': ['readonly']}}
     }
 
 
@@ -141,7 +142,7 @@ class Test(object):
             logging.info("TCP data error counter: %d" % self.total_tcp_err_cnt)
             logging.info("TCP exception counter: %d" % self.tcp_exception_cnt)
             logging.info("TCP write busy counter: %d" % self.dut['REGISTERS'].TCP_FAILED_WRITE_CNT)
-            logging.info("TCP data words: read: %d, expected: %d" % (self.dut['REGISTERS'].TCP_WRITE_CNT, self.total_tcp_data_words_read))
+            logging.info("TCP data words: read: %d, expected: %d" % (self.dut['REGISTERS'].TCP_WRITE_CNT * 4 + self.dut['REGISTERS'].TCP_RECV_WRITE_CNT, self.total_tcp_data_words_read * 4))
             if self.total_tcp_data_words_read * 4 / 10.0**6 > 1000000:
                 logging.info("Total amount transmitted: %.2f TB" % (self.total_tcp_data_words_read * 4 / 10.0**12))
             elif self.total_tcp_data_words_read * 4 / 10.0**6 > 1000:

--- a/examples/test_eth/test_eth.py
+++ b/examples/test_eth/test_eth.py
@@ -137,11 +137,11 @@ class Test(object):
         # some statistics
         logging.info("Total time: %s" % (str(datetime.timedelta(seconds=self.time_stop - self.time_start))))
         if test_tcp:
-            logging.info("TCP transfer statistics:")
-            logging.info("TCP total data error counter: %d" % self.total_tcp_err_cnt)
-            logging.info("TCP total data words: read: %d, expected: %d" % (self.dut['REGISTERS'].TCP_WRITE_CNT, self.total_tcp_data_words_read))
-            logging.info("TCP total data words failed: %d" % self.dut['REGISTERS'].TCP_FAILED_WRITE_CNT)
+            logging.info("=== TCP transfer statistics ===")
+            logging.info("TCP data error counter: %d" % self.total_tcp_err_cnt)
             logging.info("TCP exception counter: %d" % self.tcp_exception_cnt)
+            logging.info("TCP write busy counter: %d" % self.dut['REGISTERS'].TCP_FAILED_WRITE_CNT)
+            logging.info("TCP data words: read: %d, expected: %d" % (self.dut['REGISTERS'].TCP_WRITE_CNT, self.total_tcp_data_words_read))
             if self.total_tcp_data_words_read * 4 / 10.0**6 > 1000000:
                 logging.info("Total amount transmitted: %.2f TB" % (self.total_tcp_data_words_read * 4 / 10.0**12))
             elif self.total_tcp_data_words_read * 4 / 10.0**6 > 1000:
@@ -156,10 +156,10 @@ class Test(object):
                     logging.info("TCP read speed (min/median/average/max): %.2f/%.2f/%.2f/%.2f Mbit/s" % (np.min(self.tcp_read_speeds), np.median(self.tcp_read_speeds), np.average(self.tcp_read_speeds), np.max(self.tcp_read_speeds)))
 
         if test_udp:
-            logging.info("UDP transfer statistics:")
-            logging.info("UDP total data words failed: %d" % self.total_udp_err_cnt)
-            logging.info("UDP total read/write counter: read: %d, expected: %d" % (self.dut['REGISTERS'].UDP_WRITE_CNT, self.total_udp_read_write_cnt * 8))
+            logging.info("=== UDP transfer statistics ===")
+            logging.info("UDP data error counter: %d" % self.total_udp_err_cnt)
             logging.info("UDP exception counter: %d" % self.udp_exception_cnt)
+            logging.info("UDP read/write counter: read: %d, expected: %d" % (self.dut['REGISTERS'].UDP_WRITE_CNT, self.total_udp_read_write_cnt * 8))
             if self.total_udp_read_write_cnt * 8 / 10.0**6 > 1000000:
                 logging.info("Total amount transmitted: %.2f TB" % (self.total_udp_read_write_cnt * 8 / 10.0**12))
             elif self.total_udp_read_write_cnt * 8 / 10.0**6 > 1000:

--- a/examples/test_eth/test_eth.py
+++ b/examples/test_eth/test_eth.py
@@ -24,6 +24,7 @@ transfer_layer:
         udp_port : 4660
         tcp_port : 24
         tcp_connection : True
+        tcp_to_bus : True
 
 hw_drivers:
   - name      : SITCP_FIFO

--- a/examples/test_eth/test_eth.py
+++ b/examples/test_eth/test_eth.py
@@ -1,8 +1,11 @@
 import logging
 import signal
 import time
-import random
+import datetime
+# import random
 from threading import Thread, Event  # , Lock, Condition
+from array import array
+import struct
 
 import numpy as np
 
@@ -59,93 +62,153 @@ class Test(object):
         self.dut = Dut(conf)
         self.dut.init()
         # fw_version = dut['ETH'].read(0x0000, 1)[0]
-        print "Firmware version: ", self.dut['REGISTERS'].VERSION
+        logging.info("Firmware version: %s" % self.dut['REGISTERS'].VERSION)
 
         signal.signal(signal.SIGINT, self.signal_handler)
         logging.info('Press Ctrl-C to stop')
 
         self.stop_thread = Event()
-        self.total_data_err_cnt = 0
+        self.total_tcp_err_cnt = 0
 
     def signal_handler(self, signum, frame):
         logging.info('Pressed Ctrl-C...')
+        self.dut['REGISTERS'].TCP_WRITE_DLY = 0  # no TCP data
+        self.time_stop = time.time()
         self.stop_thread.set()
         signal.signal(signal.SIGINT, signal.SIG_DFL)  # setting default handler
 
-    def start(self, test_tcp=True, test_udp=True):
+    def start(self, test_tcp=True, test_udp=True, tcp_write_delay=6, monitor_interval=1.0):
+        if not test_tcp and not test_udp:
+            return
+        self.test_tcp = test_tcp
+        self.test_udp = test_udp
         # reset registers
         self.dut['REGISTERS'].RESET
         # setup register values
-        self.monitor_delay = 3.0  # Speed of displaying netowrk speed
+        # Monitor
+        self.monitor_delay = monitor_interval  # Speed of displaying netowrk speed
+        # TCP
         self.tcp_readout_delay = 0.1  # Delay between reading TCP buffer
-        self.dut['REGISTERS'].TCP_WRITE_DLY = 6  # set TCP write delay: 1 equivalent to write data every clock cycle (1/133MHz=0.0075us=7.5ns)
-        self.total_data_err_cnt = 0
-        self.total_data_words_read = 0
+        self.dut['REGISTERS'].TCP_WRITE_DLY = 0  # no TCP data
+        self.time_start = time.time()
+        self.total_tcp_err_cnt = 0
+        self.total_tcp_data_words_read = 0
+        self.tcp_exception_cnt = 0
+        self.tcp_read_speeds = None
+        # UDP
         self.udp_readout_delay = 0.0  # Delay between reading/writing UDP
         self.total_udp_err_cnt = 0
         self.total_udp_read_write_cnt = 0
-
+        self.udp_exception_cnt = 0
+        self.udp_read_write_speeds = None
+        # initializing threads
         self.stop_thread.clear()
         self.mon_t = Thread(target=self.monitor, name='Monitor thread', kwargs={})
         self.mon_t.daemon = True
-        self.tcp_t = Thread(target=self.tcp_read, name='TCP thread', kwargs={})
-        self.tcp_t.daemon = True
-        self.udp_t = Thread(target=self.udp_read_write, name='UDP thread', kwargs={})
-        self.udp_t.daemon = True
         self.mon_t.start()
         if test_tcp:
+            self.tcp_t = Thread(target=self.tcp_read, name='TCP thread', kwargs={})
+            self.tcp_t.daemon = True
             self.tcp_t.start()
         if test_udp:
+            self.udp_t = Thread(target=self.udp_read_write, name='UDP thread', kwargs={})
+            self.udp_t.daemon = True
             self.udp_t.start()
+        if test_tcp:
+            self.dut['REGISTERS'].TCP_WRITE_DLY = tcp_write_delay  # set TCP write delay: 1 equivalent to write data every clock cycle (1/133MHz=0.0075us=7.5ns)
+        self.time_start = time.time()
+        self.time_stop = self.time_start + 1.0
+        # while loop for signal handler
         while not self.stop_thread.wait(0.05):
             pass
-        self.tcp_t.join()
+        self.mon_t.join()
+        self.mon_t = None
         logging.info("Stopped Monitor thread")
-        self.tcp_t.join()
-        logging.info("Stopped TCP thread")
-        self.udp_t.join()
-        logging.info("Stopped UDP thread")
-        self.tcp_t = None
+        if test_tcp:
+            self.tcp_t.join()
+            self.tcp_t = None
+            logging.info("Stopped TCP thread")
+        if test_udp:
+            self.udp_t.join()
+            self.udp_t = None
+            logging.info("Stopped UDP thread")
+
         # some statistics
+        logging.info("Total time: %s" % (str(datetime.timedelta(seconds=self.time_stop - self.time_start))))
         if test_tcp:
             logging.info("TCP transfer statistics:")
-            logging.info("TCP total data error counter: %d" % self.total_data_err_cnt)
-            logging.info("TCP total data words: expected: %d / read: %d" % (self.dut['REGISTERS'].TCP_WRITE_CNT, self.total_data_words_read))
+            logging.info("TCP total data error counter: %d" % self.total_tcp_err_cnt)
+            logging.info("TCP total data words: read: %d, expected: %d" % (self.dut['REGISTERS'].TCP_WRITE_CNT, self.total_tcp_data_words_read))
             logging.info("TCP total data words failed: %d" % self.dut['REGISTERS'].TCP_FAILED_WRITE_CNT)
-            if self.total_data_words_read * 4 / 10.0**6 > 1000000:
-                logging.info("Total amount transmitted: %.2f TB" % (self.total_data_words_read * 4 / 10.0**12))
-            elif self.total_data_words_read * 4 / 10.0**6 > 1000:
-                logging.info("Total amount transmitted: %.2f GB" % (self.total_data_words_read * 4 / 10.0**9))
+            logging.info("TCP exception counter: %d" % self.tcp_exception_cnt)
+            if self.total_tcp_data_words_read * 4 / 10.0**6 > 1000000:
+                logging.info("Total amount transmitted: %.2f TB" % (self.total_tcp_data_words_read * 4 / 10.0**12))
+            elif self.total_tcp_data_words_read * 4 / 10.0**6 > 1000:
+                logging.info("Total amount transmitted: %.2f GB" % (self.total_tcp_data_words_read * 4 / 10.0**9))
             else:
-                logging.info("Total amount transmitted: %.2f MB" % (self.total_data_words_read * 4 / 10.0**6))
+                logging.info("Total amount transmitted: %.2f MB" % (self.total_tcp_data_words_read * 4 / 10.0**6))
+            logging.info("Total average TCP read speed: %.2f Mbits/s" % (self.total_tcp_data_words_read * 32 / (self.time_stop - self.time_start) / 10.0**6))
+            if self.tcp_read_speeds:
+                if np.average(self.tcp_read_speeds) < 1.0:
+                    logging.info("TCP read speed (min/median/average/max): %.2f/%.2f/%.2f/%.2f kbits/s" % (np.min(self.tcp_read_speeds) * 10**3, np.median(self.tcp_read_speeds) * 10**3, np.average(self.tcp_read_speeds) * 10**3, np.max(self.tcp_read_speeds) * 10**3))
+                else:
+                    logging.info("TCP read speed (min/median/average/max): %.2f/%.2f/%.2f/%.2f Mbits/s" % (np.min(self.tcp_read_speeds), np.median(self.tcp_read_speeds), np.average(self.tcp_read_speeds), np.max(self.tcp_read_speeds)))
 
         if test_udp:
             logging.info("UDP transfer statistics:")
             logging.info("UDP total data words failed: %d" % self.total_udp_err_cnt)
-            logging.info("UDP total read/write counter: expected: %d / read: %d" % (self.total_udp_read_write_cnt, self.dut['REGISTERS'].UDP_WRITE_CNT))
+            logging.info("UDP total read/write counter: read: %d, expected: %d" % (self.dut['REGISTERS'].UDP_WRITE_CNT, self.total_udp_read_write_cnt * 8))
+            logging.info("UDP exception counter: %d" % self.udp_exception_cnt)
             if self.total_udp_read_write_cnt * 8 / 10.0**6 > 1000000:
                 logging.info("Total amount transmitted: %.2f TB" % (self.total_udp_read_write_cnt * 8 / 10.0**12))
             elif self.total_udp_read_write_cnt * 8 / 10.0**6 > 1000:
                 logging.info("Total amount transmitted: %.2f GB" % (self.total_udp_read_write_cnt * 8 / 10.0**9))
             else:
                 logging.info("Total amount transmitted: %.2f MB" % (self.total_udp_read_write_cnt * 8 / 10.0**6))
+            logging.info("Total average UDP read/write speed: %.2f Mbits/s" % (self.total_udp_read_write_cnt * 64 / (self.time_stop - self.time_start) / 10.0**6))
+            if self.udp_read_write_speeds:
+                if np.average(self.udp_read_write_speeds) < 1.0:
+                    logging.info("UDP read/write speed (min/median/average/max): %.2f/%.2f/%.2f/%.2f kbits/s" % (np.min(self.udp_read_write_speeds) * 10**3, np.median(self.udp_read_write_speeds) * 10**3, np.average(self.udp_read_write_speeds) * 10**3, np.max(self.udp_read_write_speeds) * 10**3))
+                else:
+                    logging.info("UDP read/write speed (min/median/average/max): %.2f/%.2f/%.2f/%.2f Mbits/s" % (np.min(self.udp_read_write_speeds), np.median(self.udp_read_write_speeds), np.average(self.udp_read_write_speeds), np.max(self.udp_read_write_speeds)))
+
         # close DUT
         self.dut.close()
 
     def monitor(self):
         logging.info("Started Monitor thread")
         time_read = time.time()
-        last_total_data_words_read = 0
+        last_total_tcp_data_words_read = 0
         last_total_udp_read_write_cnt = 0
         while not self.stop_thread.wait(max(0.0, self.monitor_delay - time_read + time.time())):
             tmp_time_read = time.time()
-            tmp_total_data_words_read = self.total_data_words_read
+            tmp_total_tcp_data_words_read = self.total_tcp_data_words_read
             tmp_total_udp_read_write_cnt = self.total_udp_read_write_cnt
-            logging.info("TCP write speed: %0.2f Mbit/s" % ((tmp_total_data_words_read - last_total_data_words_read) * 32 / (tmp_time_read - time_read) / 10**6))
-            logging.info("UDP read/write speed: %0.2f Mbit/s" % ((tmp_total_udp_read_write_cnt - last_total_udp_read_write_cnt) * 64 / (tmp_time_read - time_read) / 10**6))
+            if self.test_tcp:
+                tcp_read_speed = (tmp_total_tcp_data_words_read - last_total_tcp_data_words_read) * 32 / (tmp_time_read - time_read) / 10**6
+                if self.tcp_read_speeds is None:  # add on second iteration
+                    self.tcp_read_speeds = []
+                else:
+                    self.tcp_read_speeds.append(tcp_read_speed)
+                if tcp_read_speed < 1.0:
+                    logging.info("TCP read speed: %0.2f kbit/s" % (tcp_read_speed * 10**3))
+                else:
+                    logging.info("TCP read speed: %0.2f Mbit/s" % tcp_read_speed)
+            if self.test_udp:
+                udp_read_write_speed = (tmp_total_udp_read_write_cnt - last_total_udp_read_write_cnt) * 64 / (tmp_time_read - time_read) / 10**6
+                if self.udp_read_write_speeds is None:  # add on second iteration
+                    self.udp_read_write_speeds = []
+                else:
+                    self.udp_read_write_speeds.append(udp_read_write_speed)
+                if udp_read_write_speed < 1.0:
+                    logging.info("UDP read/write speed: %0.2f kbit/s" % (udp_read_write_speed * 10**3))
+                else:
+                    logging.info("UDP read/write speed: %0.2f Mbit/s" % udp_read_write_speed)
             time_read = tmp_time_read
-            last_total_data_words_read = tmp_total_data_words_read
+            last_total_tcp_data_words_read = tmp_total_tcp_data_words_read
             last_total_udp_read_write_cnt = tmp_total_udp_read_write_cnt
+            if self.total_udp_err_cnt > 10 or self.total_tcp_err_cnt > 10:
+                self.stop_thread.set()
 
         logging.info("Stopping Monitor thread...")
 
@@ -158,19 +221,24 @@ class Test(object):
             time_read = time.time()
             if self.stop_thread.is_set():
                 self.dut['REGISTERS'].TCP_WRITE_DLY = 0
-            fifo_data = self.dut['SITCP_FIFO'].get_data()
-            if fifo_data.shape[0]:
-                self.total_data_words_read += fifo_data.shape[0]
-                if fifo_data[0] != fifo_data_last_value + 1:
-                    logging.warning("TCP not increased by 1 between readouts")
-                    self.total_data_err_cnt += (np.abs(fifo_data[0] - fifo_data_last_value + 1))
-                err_cnt = np.count_nonzero(np.diff(fifo_data) != 1)
-                if err_cnt:
-                    logging.warning("TCP data not increased by 1: errors=%d" % err_cnt)
-                    self.total_data_err_cnt += err_cnt
-                fifo_data_last_value = fifo_data[-1]
-            elif self.stop_thread.is_set():
-                fifo_was_empty += 1
+            try:
+                fifo_data = self.dut['SITCP_FIFO'].get_data()
+            except Exception as e:
+                logging.error(e)
+                self.tcp_exception_cnt += 1
+            else:
+                if fifo_data.shape[0]:
+                    self.total_tcp_data_words_read += fifo_data.shape[0]
+                    if fifo_data[0] != fifo_data_last_value + 1:
+                        logging.warning("TCP not increased by 1 between readouts")
+                        self.total_tcp_err_cnt += (np.abs(fifo_data[0] - fifo_data_last_value + 1))
+                    err_cnt = np.count_nonzero(np.diff(fifo_data) != 1)
+                    if err_cnt:
+                        logging.warning("TCP data not increased by 1: errors=%d" % err_cnt)
+                        self.total_tcp_err_cnt += err_cnt
+                    fifo_data_last_value = fifo_data[-1]
+                elif self.stop_thread.is_set():
+                    fifo_was_empty += 1
             if self.stop_thread.is_set():
                 time.sleep(max(0.0, self.tcp_readout_delay - time_read + time.time()))
         logging.info("Stopping TCP thread...")
@@ -180,19 +248,46 @@ class Test(object):
         time_read = time.time()
         while not self.stop_thread.wait(max(0.0, self.udp_readout_delay - time_read + time.time())):
             time_read = time.time()
-            write_value = random.randint(0, 2**64 - 1)
-            self.dut['REGISTERS'].TEST_DATA = write_value
-            read_value = self.dut['REGISTERS'].TEST_DATA
-            self.total_udp_read_write_cnt += 8
-            if read_value != write_value:
-                logging.warning("UDP data not correct: read: %d / expected: %d" % (read_value, write_value))
-                self.total_udp_err_cnt += 1
-            write_value = (write_value + 1) % 2**64  # set max value
-        self.dut['REGISTERS'].TEST_DATA = 0
-        self.total_udp_read_write_cnt += 8
+            write_value = long(np.random.randint(2**64, size=None, dtype=np.uint64))  # random.randint(0, 2**64 - 1)
+            try:
+                self.dut['REGISTERS'].TEST_DATA = write_value
+            except Exception as e:
+                logging.error(e)
+                self.udp_exception_cnt += 1
+            else:
+                try:
+                    read_value = self.dut['REGISTERS'].TEST_DATA
+                except Exception as e:
+                    logging.error(e)
+                    self.udp_exception_cnt += 1
+                else:
+                    self.total_udp_read_write_cnt += 1
+                    if read_value != write_value:
+                        logging.warning("UDP data not correct: read: %s, expected: %s" % (array('B', struct.unpack("BBBBBBBB", struct.pack("Q", read_value))), array('B', struct.unpack("BBBBBBBB", struct.pack("Q", write_value)))))
+                        self.total_udp_err_cnt += 1
         logging.info("Stopping UDP thread...")
 
 
 if __name__ == "__main__":
+    import argparse
+    parser = argparse.ArgumentParser(description='Testing MMC3 Ethernet Interface %s\nExample: python test_eth.py -t 1.0 -d 6 --no-udp --no-tcp', formatter_class=argparse.RawTextHelpFormatter)
+    parser.add_argument('-t', '--time', type=float, metavar='<interval time>', action='store', help='time interval for the monitor')
+    parser.add_argument('-d', '--delay', type=int, metavar='<clock cycles>', action='store', help='clock cycles between TCP writes')
+    parser.add_argument('--no_udp', dest='no_udp', action='store_true', help='disable UDP tests')
+    parser.add_argument('--no_tcp', dest='no_tcp', action='store_true', help='disable TCP tests')
+    parser.set_defaults(no_m26_jtag_configuration=False)
+    args = parser.parse_args()
+
+    config = {}
+
+    if args.time is not None:
+        config["monitor_interval"] = args.time
+    if args.delay is not None:
+        config["tcp_write_delay"] = args.delay
+    if args.no_udp:
+        config["test_udp"] = False
+    if args.no_tcp:
+        config["test_tcp"] = False
+
     test = Test()
-    test.start()
+    test.start(**config)

--- a/examples/test_eth/test_eth.py
+++ b/examples/test_eth/test_eth.py
@@ -147,12 +147,12 @@ class Test(object):
                 logging.info("Total amount transmitted: %.2f GB" % (self.total_tcp_data_words_read * 4 / 10.0**9))
             else:
                 logging.info("Total amount transmitted: %.2f MB" % (self.total_tcp_data_words_read * 4 / 10.0**6))
-            logging.info("Total average TCP read speed: %.2f Mbits/s" % (self.total_tcp_data_words_read * 32 / (self.time_stop - self.time_start) / 10.0**6))
+            logging.info("Total average TCP read speed: %.2f Mbit/s" % (self.total_tcp_data_words_read * 32 / (self.time_stop - self.time_start) / 10.0**6))
             if self.tcp_read_speeds:
                 if np.average(self.tcp_read_speeds) < 1.0:
-                    logging.info("TCP read speed (min/median/average/max): %.2f/%.2f/%.2f/%.2f kbits/s" % (np.min(self.tcp_read_speeds) * 10**3, np.median(self.tcp_read_speeds) * 10**3, np.average(self.tcp_read_speeds) * 10**3, np.max(self.tcp_read_speeds) * 10**3))
+                    logging.info("TCP read speed (min/median/average/max): %.2f/%.2f/%.2f/%.2f kbit/s" % (np.min(self.tcp_read_speeds) * 10**3, np.median(self.tcp_read_speeds) * 10**3, np.average(self.tcp_read_speeds) * 10**3, np.max(self.tcp_read_speeds) * 10**3))
                 else:
-                    logging.info("TCP read speed (min/median/average/max): %.2f/%.2f/%.2f/%.2f Mbits/s" % (np.min(self.tcp_read_speeds), np.median(self.tcp_read_speeds), np.average(self.tcp_read_speeds), np.max(self.tcp_read_speeds)))
+                    logging.info("TCP read speed (min/median/average/max): %.2f/%.2f/%.2f/%.2f Mbit/s" % (np.min(self.tcp_read_speeds), np.median(self.tcp_read_speeds), np.average(self.tcp_read_speeds), np.max(self.tcp_read_speeds)))
 
         if test_udp:
             logging.info("UDP transfer statistics:")
@@ -165,12 +165,12 @@ class Test(object):
                 logging.info("Total amount transmitted: %.2f GB" % (self.total_udp_read_write_cnt * 8 / 10.0**9))
             else:
                 logging.info("Total amount transmitted: %.2f MB" % (self.total_udp_read_write_cnt * 8 / 10.0**6))
-            logging.info("Total average UDP read/write speed: %.2f Mbits/s" % (self.total_udp_read_write_cnt * 64 / (self.time_stop - self.time_start) / 10.0**6))
+            logging.info("Total average UDP read/write speed: %.2f Mbit/s" % (self.total_udp_read_write_cnt * 64 / (self.time_stop - self.time_start) / 10.0**6))
             if self.udp_read_write_speeds:
                 if np.average(self.udp_read_write_speeds) < 1.0:
-                    logging.info("UDP read/write speed (min/median/average/max): %.2f/%.2f/%.2f/%.2f kbits/s" % (np.min(self.udp_read_write_speeds) * 10**3, np.median(self.udp_read_write_speeds) * 10**3, np.average(self.udp_read_write_speeds) * 10**3, np.max(self.udp_read_write_speeds) * 10**3))
+                    logging.info("UDP read/write speed (min/median/average/max): %.2f/%.2f/%.2f/%.2f kbit/s" % (np.min(self.udp_read_write_speeds) * 10**3, np.median(self.udp_read_write_speeds) * 10**3, np.average(self.udp_read_write_speeds) * 10**3, np.max(self.udp_read_write_speeds) * 10**3))
                 else:
-                    logging.info("UDP read/write speed (min/median/average/max): %.2f/%.2f/%.2f/%.2f Mbits/s" % (np.min(self.udp_read_write_speeds), np.median(self.udp_read_write_speeds), np.average(self.udp_read_write_speeds), np.max(self.udp_read_write_speeds)))
+                    logging.info("UDP read/write speed (min/median/average/max): %.2f/%.2f/%.2f/%.2f Mbit/s" % (np.min(self.udp_read_write_speeds), np.median(self.udp_read_write_speeds), np.average(self.udp_read_write_speeds), np.max(self.udp_read_write_speeds)))
 
         # close DUT
         self.dut.close()

--- a/firmware/modules/utils/fifo_8_to_32.v
+++ b/firmware/modules/utils/fifo_8_to_32.v
@@ -1,0 +1,109 @@
+/**
+ * ------------------------------------------------------------
+ * Copyright (c) All rights reserved
+ * SiLab, Institute of Physics, University of Bonn
+ * ------------------------------------------------------------
+ */
+`timescale 1ps/1ps
+`default_nettype none
+
+
+module fifo_8_to_32 #(
+    parameter DEPTH = 1024
+)(
+    input wire CLK,
+    input wire RST,
+
+    input wire WRITE,
+    input wire READ,
+    input wire [7:0] DATA_IN,
+    output wire FULL,
+    output wire EMPTY,
+    output wire [31:0] DATA_OUT
+);
+
+
+wire FIFO_EMPTY_8;
+wire FIFO_READ_8;
+wire [7:0] FIFO_DATA_OUT_8;
+
+gerneric_fifo #(.DATA_SIZE(8), .DEPTH(DEPTH * 4)) fifo_8_i
+(
+    .clk(CLK),
+    .reset(RST),
+    .write(WRITE),
+    .read(FIFO_READ_8),
+    .data_in(DATA_IN),
+    .full(FULL),
+    .empty(FIFO_EMPTY_8),
+    .data_out(FIFO_DATA_OUT_8),
+    .size()
+);
+
+
+wire FIFO_FULL_32;
+reg FIFO_WRITE_32;
+wire [31:0] FIFO_DATA_IN_32;
+
+reg [1:0] byte_cnt;
+reg WAIT_FOR_FIFO_32;
+always@(posedge CLK)
+    if(RST) begin
+        byte_cnt <= 0;
+        WAIT_FOR_FIFO_32 <= 1'b0;
+    end else if(~WAIT_FOR_FIFO_32 && ~FIFO_EMPTY_8 && &byte_cnt) begin
+        byte_cnt <= byte_cnt;
+        WAIT_FOR_FIFO_32 <= 1'b1;
+    end else if((~FIFO_EMPTY_8 && ~&byte_cnt) || (FIFO_WRITE_32 && &byte_cnt)) begin
+        byte_cnt <= byte_cnt + 1;
+        WAIT_FOR_FIFO_32 <= 1'b0;
+    end else begin
+        byte_cnt <= byte_cnt;
+        WAIT_FOR_FIFO_32 <= WAIT_FOR_FIFO_32;
+    end
+
+wire READ_FIFO_8;
+assign READ_FIFO_8 = (~FIFO_EMPTY_8 && ~WAIT_FOR_FIFO_32);
+assign FIFO_READ_8 = READ_FIFO_8;
+
+always@(posedge CLK)
+    if(RST) begin
+        FIFO_WRITE_32 <= 1'b0;
+    end else if(FIFO_WRITE_32) begin
+        FIFO_WRITE_32 <= 1'b0;
+    end else if(~FIFO_FULL_32 && &byte_cnt && WAIT_FOR_FIFO_32) begin
+        FIFO_WRITE_32 <= 1'b1;
+    end
+
+reg [31:0] DATA_BUF;
+always@(posedge CLK)
+    if(RST) begin
+        DATA_BUF = 0;
+    end else if(READ_FIFO_8 && byte_cnt  == 0) begin
+        DATA_BUF[7:0] <= FIFO_DATA_OUT_8;
+    end else if(READ_FIFO_8 && byte_cnt  == 1) begin
+        DATA_BUF[15:8] <= FIFO_DATA_OUT_8;
+    end else if(READ_FIFO_8 && byte_cnt  == 2) begin
+        DATA_BUF[23:16] <= FIFO_DATA_OUT_8;
+    end else if(READ_FIFO_8 && byte_cnt  == 3) begin
+        DATA_BUF[31:24] <= FIFO_DATA_OUT_8;
+    end else begin
+        DATA_BUF <= DATA_BUF;
+    end
+
+assign FIFO_DATA_IN_32 = DATA_BUF;
+
+gerneric_fifo #(.DATA_SIZE(32), .DEPTH(DEPTH)) fifo_32_i
+(
+    .clk(CLK),
+    .reset(RST),
+    .write(FIFO_WRITE_32),
+    .read(READ),
+    .data_in(FIFO_DATA_IN_32),
+    .full(FIFO_FULL_32),
+    .empty(EMPTY),
+    .data_out(DATA_OUT),
+    .size()
+);
+
+endmodule

--- a/firmware/modules/utils/rbcp_to_bus.v
+++ b/firmware/modules/utils/rbcp_to_bus.v
@@ -42,8 +42,8 @@ always@(posedge BUS_CLK) begin
 end
 
 assign BUS_ADD = RBCP_ADDR;
-assign BUS_WR = RBCP_WE; //tofix
-assign BUS_RD = RBCP_RE;
+assign BUS_WR = RBCP_WE & RBCP_ACT;
+assign BUS_RD = RBCP_RE & RBCP_ACT;
 
 assign BUS_DATA = BUS_WR ? RBCP_WD[7:0]: 8'bz;
 assign RBCP_RD[7:0] = BUS_WR ? 8'bz : BUS_DATA;

--- a/firmware/modules/utils/tcp_to_bus.v
+++ b/firmware/modules/utils/tcp_to_bus.v
@@ -148,7 +148,7 @@ assign RBCP_RD[7:0] = BUS_WR ? 8'bz : BUS_DATA;
 
 // BUS
 assign BUS_WR = TCP_TO_BUS_WR | RBCP_TO_BUS_WR;
-assign BUS_RD = RBCP_RE & RBCP_ACT & ~TCP_TO_BUS_WR;
+assign BUS_RD = RBCP_RE & RBCP_ACT & ~BUS_WR;
 assign BUS_ADD = (TCP_TO_BUS_WR) ? TCP_TO_BUS_ADD : RBCP_ADDR;
 assign BUS_DATA = (BUS_WR) ? ((TCP_TO_BUS_WR) ? TCP_RX_DATA : RBCP_WD) : 8'bz;
 

--- a/firmware/modules/utils/tcp_to_bus.v
+++ b/firmware/modules/utils/tcp_to_bus.v
@@ -1,0 +1,102 @@
+/**
+ * ------------------------------------------------------------
+ * Copyright (c) All rights reserved
+ * SiLab, Institute of Physics, University of Bonn
+ * ------------------------------------------------------------
+ */
+
+`timescale 1ps / 1ps
+`default_nettype none
+
+module tcp_to_bus (
+    input wire BUS_RST,
+    input wire BUS_CLK,
+
+    // SiTCP TCP RX
+    output reg [15:0] TCP_RX_WC, // Rx FIFO write count[15:0] (Unused bits should be set 1)
+    input wire        TCP_RX_WR, // Write enable
+    input wire [7:0]  TCP_RX_DATA, // Write data[7:0]
+    //input wire TCP_TX_FULL, // Almost full flag
+    //output wire TCP_TX_WR, // Write enable
+    //output reg TCP_TX_DATA, // Write data[7:0]
+
+    // BUS
+    output wire          BUS_WR,
+    //output wire          BUS_RD,
+    output reg  [31:0]   BUS_ADD,
+    output wire [7:0]    BUS_DATA
+);
+
+
+always@(posedge BUS_CLK)
+    if(BUS_RST) begin
+        TCP_RX_WC <= 0;
+    end else if(TCP_RX_WR) begin
+        TCP_RX_WC <= TCP_RX_WC + 1;
+    end else begin
+        TCP_RX_WC <= 0;
+    end
+
+reg INVALID;
+reg [15:0] LENGTH;
+reg [15:0] byte_cnt;
+always@(posedge BUS_CLK)
+    if(BUS_RST) begin
+        byte_cnt <= 0;
+    end else if(INVALID && !TCP_RX_WR) begin
+        byte_cnt <= 0;
+    end else if((byte_cnt >= 5) && ((byte_cnt - 5) == LENGTH)) begin
+        byte_cnt <= 0;
+    end else if(TCP_RX_WR) begin
+        byte_cnt <= byte_cnt + 1;
+    end else begin
+        byte_cnt <= byte_cnt;
+    end
+
+// invalid signal will prevent from writing to BUS
+// invalid signal will be reset when TCP write request is de-asserted
+always@(posedge BUS_CLK)
+    if (BUS_RST)
+        INVALID <= 1'b0;
+    if (!TCP_RX_WR)
+        INVALID <= 1'b0;
+    // check for correct length, substract header size 6
+    // check for correct max. address
+    else if (({TCP_RX_DATA, LENGTH[7:0]} > 65529 && byte_cnt == 1) || ((LENGTH + {TCP_RX_DATA, BUS_ADD[23:0]} > 33'h1_0000_0000) && byte_cnt == 5))
+        INVALID <= 1'b1;
+    else
+        INVALID <= INVALID;
+
+always@(posedge BUS_CLK)
+    if(BUS_RST) begin
+        LENGTH <= 0;
+    end else if(TCP_RX_WR && byte_cnt == 0) begin
+        LENGTH[7:0] <= TCP_RX_DATA;
+    end else if(TCP_RX_WR && byte_cnt == 1) begin
+        LENGTH[15:8] <= TCP_RX_DATA;
+    end else begin
+        LENGTH <= LENGTH;
+    end
+
+assign BUS_WR = (TCP_RX_WR && byte_cnt > 5 && !INVALID) ? 1'b1 : 1'b0;
+
+  always@(posedge BUS_CLK)
+    if(BUS_RST) begin
+        BUS_ADD <= 0;
+    end else if(TCP_RX_WR && byte_cnt == 2) begin
+        BUS_ADD[7:0] <= TCP_RX_DATA;
+    end else if(TCP_RX_WR && byte_cnt == 3) begin
+        BUS_ADD[15:8] <= TCP_RX_DATA;
+    end else if(TCP_RX_WR && byte_cnt == 4) begin
+        BUS_ADD[23:16] <= TCP_RX_DATA;
+    end else if(TCP_RX_WR && byte_cnt == 5) begin
+        BUS_ADD[31:24] <= TCP_RX_DATA;
+    end else if(TCP_RX_WR && byte_cnt > 5) begin
+        BUS_ADD <= BUS_ADD + 1;
+    end else begin
+        BUS_ADD <= BUS_ADD;
+    end
+
+assign BUS_DATA = (BUS_WR) ? TCP_RX_DATA : 8'bz;
+
+endmodule

--- a/tests/test_SimFifo8to32.py
+++ b/tests/test_SimFifo8to32.py
@@ -1,0 +1,84 @@
+#
+# ------------------------------------------------------------
+# Copyright (c) All rights reserved
+# SiLab, Institute of Physics, University of Bonn
+# ------------------------------------------------------------
+#
+
+import unittest
+import os
+
+from basil.dut import Dut
+from basil.utils.sim.utils import cocotb_compile_and_run, cocotb_compile_clean
+
+
+cnfg_yaml = """
+transfer_layer:
+  - name  : INTF
+    type  : SiSim
+    init:
+        host : localhost
+        port  : 12345
+
+hw_drivers:
+  - name      : FIFO
+    type      : bram_fifo
+    interface : INTF
+    base_addr : 0x8000
+    base_data_addr: 0x80000000
+"""
+
+
+class TestSimM26(unittest.TestCase):
+    def setUp(self):
+        cocotb_compile_and_run([os.path.join(os.path.dirname(__file__), 'test_SimFifo8to32.v')])
+
+        self.chip = Dut(cnfg_yaml)
+        self.chip.init()
+
+    def test_io(self):
+        for i in range(4):
+            self.chip['INTF'].write(0x1000, [i])
+
+        data = []
+        iterations = 1000
+        i = 0
+        while not len(data) == 1:
+            if i >= iterations:
+                break
+            data.extend(self.chip['FIFO'].get_data())
+            i += 1
+        assert data[0] == 50462976
+
+        self.chip['INTF'].write(0x1000, [4, 5, 6, 7])
+
+        data = []
+        iterations = 1000
+        i = 0
+        while not len(data) == 1:
+            if i >= iterations:
+                break
+            data.extend(self.chip['FIFO'].get_data())
+            i += 1
+        assert data[0] == 117835012
+
+        self.chip['INTF'].write(0x1000, range(8))
+
+        data = []
+        iterations = 1000
+        i = 0
+        while not len(data) == 2:
+            if i >= iterations:
+                break
+            data.extend(self.chip['FIFO'].get_data())
+            i += 1
+        assert data[0] == 50462976
+        assert data[1] == 117835012
+
+    def tearDown(self):
+        self.chip.close()  # let it close connection and stop simulator
+        cocotb_compile_clean()
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/test_SimFifo8to32.v
+++ b/tests/test_SimFifo8to32.v
@@ -1,0 +1,101 @@
+/**
+ * ------------------------------------------------------------
+ * Copyright (c) All rights reserved
+ * SiLab, Institute of Physics, University of Bonn
+ * ------------------------------------------------------------
+ */
+
+`timescale 1ps / 1ps
+
+`include "utils/bus_to_ip.v"
+
+`include "utils/cdc_syncfifo.v"
+`include "utils/fifo_8_to_32.v"
+`include "utils/generic_fifo.v"
+
+`include "bram_fifo/bram_fifo_core.v"
+`include "bram_fifo/bram_fifo.v"
+
+module tb (
+    input wire          BUS_CLK,
+    input wire          BUS_RST,
+    input wire  [31:0]  BUS_ADD,
+    inout wire  [31:0]  BUS_DATA,
+    input wire          BUS_RD,
+    input wire          BUS_WR,
+    output wire         BUS_BYTE_ACCESS
+);
+    localparam FIFO_BASEADDR = 32'h8000;
+    localparam FIFO_HIGHADDR = 32'h9000 - 1;
+
+    localparam FIFO_BASEADDR_DATA = 32'h8000_0000;
+    localparam FIFO_HIGHADDR_DATA = 32'h9000_0000-1;
+
+    localparam ABUSWIDTH = 32;
+    assign BUS_BYTE_ACCESS = BUS_ADD < 32'h8000_0000 ? 1'b1 : 1'b0;
+
+
+
+    wire FIFO_READ_RX;
+    wire FIFO_EMPTY_RX;
+    wire [31:0] FIFO_DATA_RX;
+    wire cdc_fifo_write;
+    assign cdc_fifo_write = (BUS_ADD >= 32'h1000 && BUS_ADD < 32'h8000) & BUS_WR;
+
+    wire fifo_full, cdc_fifo_empty;
+    wire [7:0] cdc_data_out;
+    cdc_syncfifo #(.DSIZE(8), .ASIZE(3)) cdc_syncfifo_i
+    (
+        .rdata(cdc_data_out),
+        .wfull(),
+        .rempty(cdc_fifo_empty),
+        .wdata(BUS_DATA),
+        .winc(cdc_fifo_write), .wclk(BUS_CLK), .wrst(BUS_RST),
+        .rinc(!fifo_full), .rclk(BUS_CLK), .rrst(BUS_RST)
+    );
+
+    fifo_8_to_32 #(.DEPTH(1024)) fifo_8_to_32_i (
+        .RST(BUS_RST),
+        .CLK(BUS_CLK),
+        .WRITE(!cdc_fifo_empty),
+        .READ(FIFO_READ),
+        .DATA_IN(cdc_data_out),
+        .FULL(fifo_full),
+        .EMPTY(FIFO_EMPTY),
+        .DATA_OUT(FIFO_DATA)
+    );
+
+
+    wire FIFO_READ, FIFO_EMPTY;
+    wire [31:0] FIFO_DATA;
+    bram_fifo
+    #(
+        .BASEADDR(FIFO_BASEADDR),
+        .HIGHADDR(FIFO_HIGHADDR),
+        .BASEADDR_DATA(FIFO_BASEADDR_DATA),
+        .HIGHADDR_DATA(FIFO_HIGHADDR_DATA),
+        .ABUSWIDTH(ABUSWIDTH)
+    ) i_out_fifo (
+        .BUS_CLK(BUS_CLK),
+        .BUS_RST(BUS_RST),
+        .BUS_ADD(BUS_ADD),
+        .BUS_DATA(BUS_DATA),
+        .BUS_RD(BUS_RD),
+        .BUS_WR(BUS_WR),
+
+        .FIFO_READ_NEXT_OUT(FIFO_READ),
+        .FIFO_EMPTY_IN(FIFO_EMPTY),
+        .FIFO_DATA(FIFO_DATA),
+
+        .FIFO_NOT_EMPTY(),
+        .FIFO_FULL(),
+        .FIFO_NEAR_FULL(),
+        .FIFO_READ_ERROR()
+    );
+
+    initial begin
+        $dumpfile("test_SimFifo8to32.vcd");
+        $dumpvars(0);
+    end
+
+endmodule


### PR DESCRIPTION
- Reducing issues with UDP socket
- Retry send and recv on failure
- Set sockets to blocking (use select instead)
- Set UDP recv buffsize to expected value
- Use message ID for UDP messages
- Adding tcp_to_bus.v module (support both, UDP writing/reading and TCP writing to/from BUS)
- Adding tcp_to_bus support to SiTcp transfer layer
- Increase write speed by 50% when using tcp_to_bus
- Update ```test_eth.py``` script

This update is addressing the following issues:
- Use select to check whether the socket is ready to send or receive data (this was not the case before)
- The UDP message was successfully sent but not received (return message missing) -> resend message
- The UDP message was successfully sent but received wrong return message (message is a clone from one of the previous return messages, message was sent twice by SiTCP) -> read one more time
- The UDP interface becomes busy for several seconds -> retry sending message
- Check for pending messages before send and after recv, check message ID, and give warning message

The update is NOT addressing the following issues:
- Message and return message are OK, but reading back register gives wrong value -> **rare**
- The message was successfully sent but the return message never arrived -> resend message
(this is especially critically in case of a "start FSM" register) -> **very rare**
- Duplicate, missing and out of order packages are generally not handled correctly because message ID is not available in FPGA.

Solution:
Use tcp_to_bus.
```
transfer_layer:
  - name  : ETH
    type  : SiTcp
    init:
        ip : "192.168.10.16"
        udp_port : 4660
        tcp_port : 24
        tcp_connection : True
        tcp_to_bus : True
```
