### PR TITLE
Increase Python 3 compatibility

### DIFF
--- a/basil/HL/MIO_PLL.py
+++ b/basil/HL/MIO_PLL.py
@@ -8,6 +8,7 @@
 import logging
 
 from basil.HL.HardwareLayer import HardwareLayer
+import six
 
 logger = logging.getLogger(__name__)
 
@@ -128,7 +129,7 @@ class MIO_PLL(HardwareLayer):
                 break
             for self.div in range(2, 128):
                 q_d_f = self.q_total * self.div * fout
-                if isinstance(q_d_f, (long, int)) and q_d_f > (15 * self.fref):  # = f0 * p
+                if isinstance(q_d_f, six.integer_types) and q_d_f > (15 * self.fref):  # = f0 * p
                     if int(q_d_f) % int(self.fref) == 0:  # p, q, and d found
                         self.p_total = q_d_f / self.fref
                         while self.p_total <= 16:  # counter constraint

--- a/basil/HL/tti_ql355tp.py
+++ b/basil/HL/tti_ql355tp.py
@@ -5,6 +5,7 @@
 # ------------------------------------------------------------
 #
 
+from __future__ import print_function
 import time
 
 from basil.HL.RegisterHardwareLayer import HardwareLayer
@@ -34,7 +35,7 @@ class ttiQl355tp(HardwareLayer):
     def read(self):
         ret = self._intf.read()
         if ret[-2:] != "\r\n":
-            print "ttiTp355tp.read() terminator error"
+            print("ttiTp355tp.read() terminator error")
         return ret[:-2]
 
     def set_enable(self, on, channel=1):
@@ -52,7 +53,7 @@ class ttiQl355tp(HardwareLayer):
         """ channel: 1=OP1, 2=OP2, AUX is not suppoted"""
         ret = self.ask("I%dO?" % channel)
         if ret[-1] != "A":
-            print "ttiQl355tp.get_current() format error", ret
+            print("ttiQl355tp.get_current() format error", ret)
             return None
         return float(ret[:-1])
 
@@ -60,7 +61,7 @@ class ttiQl355tp(HardwareLayer):
         """ channel: 1=OP1, 2=OP2, AUX is not suppoted"""
         ret = self.ask("V%dO?" % channel)
         if ret[-1] != "V":
-            print "ttiQl355tp.get_voltage() format error", ret
+            print("ttiQl355tp.get_voltage() format error", ret)
             return None
         return float(ret[:-1])
 
@@ -68,7 +69,7 @@ class ttiQl355tp(HardwareLayer):
         """ channel: 1=OP1, 2=OP2, AUX is not suppoted"""
         ret = self.ask("V%d?" % channel)
         if ret[:3] != "V%d " % channel:
-            print "ttiQl355tp.get_voltage() format error", ret
+            print("ttiQl355tp.get_voltage() format error", ret)
             return None
         return float(ret[3:])
 
@@ -76,7 +77,7 @@ class ttiQl355tp(HardwareLayer):
         """ channel: 1=OP1, 2=OP2, AUX is not suppoted"""
         ret = self.ask("I%d?" % channel)
         if ret[:3] != "I%d " % channel:
-            print "ttiQl355tp.get_current_limit() format error", ret
+            print("ttiQl355tp.get_current_limit() format error", ret)
             return None
         return float(ret[3:])
 

--- a/basil/TL/SiUsb.py
+++ b/basil/TL/SiUsb.py
@@ -11,6 +11,7 @@ import os
 from SiLibUSB import GetUSBBoards, SiUSBDevice
 
 from basil.TL.SiTransferLayer import SiTransferLayer
+from six.moves import filter
 
 logger = logging.getLogger(__name__)
 
@@ -43,7 +44,7 @@ class SiUsb(SiTransferLayer):
             if not devices:
                 raise IOError('Can\'t find USB board. Connect or reset USB board!')
             else:
-                logger.info('Found USB board(s): {}'.format(', '.join(('%s with ID %s (FW %s)' % (device.board_name, filter(type(device.board_id).isdigit, device.board_id), filter(type(device.fw_version).isdigit, device.fw_version))) for device in devices)))
+                logger.info('Found USB board(s): {}'.format(', '.join(('%s with ID %s (FW %s)' % (device.board_name, list(filter(type(device.board_id).isdigit, device.board_id)), list(filter(type(device.fw_version).isdigit, device.fw_version)))) for device in devices)))
                 if len(devices) > 1:
                     raise ValueError('Please specify ID of USB board')
                 self._sidev = devices[0]

--- a/basil/TL/SiUsb3.py
+++ b/basil/TL/SiUsb3.py
@@ -11,6 +11,7 @@ import logging
 from SiLibUSB import GetUSBBoards, SiUSBDevice
 
 from basil.TL.SiTransferLayer import SiTransferLayer
+from six.moves import filter
 
 logger = logging.getLogger(__name__)
 
@@ -43,7 +44,7 @@ class SiUsb3(SiTransferLayer):
             if not devices:
                 raise IOError('Can\'t find USB board. Connect or reset USB board!')
             else:
-                logger.info('Found USB board(s): {}'.format(', '.join(('%s with ID %s (FW %s)' % (device.board_name, filter(type(device.board_id).isdigit, device.board_id), filter(type(device.fw_version).isdigit, device.fw_version))) for device in devices)))
+                logger.info('Found USB board(s): {}'.format(', '.join(('%s with ID %s (FW %s)' % (device.board_name, list(filter(type(device.board_id).isdigit, device.board_id)), list(filter(type(device.fw_version).isdigit, device.fw_version)))) for device in devices)))
                 if len(devices) > 1:
                     raise ValueError('Please specify ID of USB board')
                 self._sidev = devices[0]

--- a/basil/utils/sim/SiLibUsb.py
+++ b/basil/utils/sim/SiLibUsb.py
@@ -17,6 +17,7 @@ Communicate via a socket to the simulator
 
 """
 
+from __future__ import print_function
 import socket
 import array
 
@@ -84,8 +85,8 @@ class SiUSBDevice(object):
         self._iface.send(req)
 
     def WriteI2C(self, address, data):
-        print 'SiUSBDevice:WriteI2C', address, data  # raise NotImplementedError("To be implemented.")
+        print('SiUSBDevice:WriteI2C', address, data)  # raise NotImplementedError("To be implemented.")
 
     def ReadI2C(self, address, size):
-        print 'SiUSBDevice:ReadI2C'  # raise NotImplementedError("To be implemented.")
+        print('SiUSBDevice:ReadI2C')  # raise NotImplementedError("To be implemented.")
         return array.array('B', range(size))

--- a/basil/utils/sim/Test.py
+++ b/basil/utils/sim/Test.py
@@ -7,6 +7,7 @@
 # Initial version by Chris Higgs <chris.higgs@potentialventures.com>
 #
 
+from __future__ import print_function
 import os
 import socket
 import logging
@@ -125,7 +126,7 @@ def bringup_test(dut):
 
     ret = yield bus.read(0, 4)
 
-    print('bus.read', ret)
+    print(('bus.read', ret))
 
     for _ in range(10):
         yield RisingEdge(bus.clock)

--- a/basil/utils/utils.py
+++ b/basil/utils/utils.py
@@ -5,6 +5,7 @@
 # ------------------------------------------------------------
 #
 
+from __future__ import print_function
 import array
 import numpy as np
 from bitarray import bitarray
@@ -12,7 +13,7 @@ from bitarray import bitarray
 
 def logging(fn):
     def wrapped(*args, **kargs):
-        print('loging:', locals())
+        print(('loging:', locals()))
 #         if args:
 #             print("loging: arguments: " + str(args))
 #         if kargs:

--- a/examples/lab_devices/MotorStage.py
+++ b/examples/lab_devices/MotorStage.py
@@ -8,10 +8,11 @@
 ''' This script shows how to use a Motor Stage
 '''
 
+from __future__ import print_function
 from basil.dut import Dut
 
 dut = Dut('mercury_pyserial.yaml')
 dut.init()
-print dut["MotorStage"].get_position()
+print(dut["MotorStage"].get_position())
 # dut["MotorStage"].set_position(100000)
 

--- a/examples/lab_devices/ProbeStation.py
+++ b/examples/lab_devices/ProbeStation.py
@@ -18,9 +18,10 @@ application, pbrs232.exe) to a virtual one.
 This virtual one is then used to steer the probe station within BASIL.
 '''
 
+from __future__ import print_function
 from basil.dut import Dut
 
 dut = Dut('suss_pa_200.yaml')
 dut.init()
-print dut['SussProber'].get_position()
-print dut['SussProber'].get_die()
+print(dut['SussProber'].get_position())
+print(dut['SussProber'].get_die())

--- a/examples/lab_devices/scpi_devices.py
+++ b/examples/lab_devices/scpi_devices.py
@@ -12,19 +12,20 @@
     all laboratory devices (> 90%) over TCP, RS232, USB, GPIB (Windows only so far).
     '''
 
+from __future__ import print_function
 from basil.dut import Dut
 
 # Talk to a Keithley device via serial port using pySerial
 dut = Dut('keithley2400_pyserial.yaml')
 dut.init()
-print dut['Sourcemeter'].get_name()
+print(dut['Sourcemeter'].get_name())
 
 # Talk to a Keithley device via serial port using VISA with Serial interface
 dut = Dut('keithley2400_pyvisa.yaml')
 dut.init()
-print dut['Sourcemeter'].get_name()
+print(dut['Sourcemeter'].get_name())
 # Some additional implemented methods for this device
-print dut['Sourcemeter'].get_voltage()
+print(dut['Sourcemeter'].get_voltage())
 dut['Sourcemeter'].off()
 dut['Sourcemeter'].set_voltage(3.14159)
 dut['Sourcemeter'].set_current_limit(.9265)
@@ -32,10 +33,10 @@ dut['Sourcemeter'].set_current_limit(.9265)
 # Example of a SCPI device implementing more specialized functions (e.g. unit conversion) via extra class definitions
 dut = Dut('agilent33250a_pyserial.yaml')
 dut.init()
-print dut['Pulser'].get_info()
+print(dut['Pulser'].get_info())
 # Some additional implemented methods for this device
 dut['Pulser'].set_voltage(0., 1., unit='V')
-print dut['Pulser'].get_voltage(0, unit='mV'), 'mV'
+print(dut['Pulser'].get_voltage(0, unit='mV'), 'mV')
 
 # Example for device with multiple channels
 dut = Dut('ttiql335tp_pyvisa.yaml')
@@ -46,10 +47,10 @@ dut['PowerSupply'].get_voltage(channel=1)
 # Talk to a Keithley device via GPIB using NI VISA
 dut = Dut('keithley2000_pyvisa.yaml')
 dut.init()
-print dut['Multimeter'].get_name()
+print(dut['Multimeter'].get_name())
 
 # Talk to a Tektronix mixed signal oscilloscope via TCPIP, USB
 dut = Dut('tektronixMSO4104B_pyvisa.yaml')
 dut.init()
-print dut['Oscilloscope'].get_name()
-print dut['Oscilloscope'].get_data(channel=1)
+print(dut['Oscilloscope'].get_name())
+print(dut['Oscilloscope'].get_data(channel=1))

--- a/examples/lab_devices/temperature_control.py
+++ b/examples/lab_devices/temperature_control.py
@@ -11,28 +11,29 @@ The Sensition sensors are read using the Sensirion EK-H4 multiplexer box from th
 For the communication with the Binder MK 53 also  a serial TL has to be used (http://www.binder-world.com).
 '''
 
+from __future__ import print_function
 from basil.dut import Dut
 
 # Sensirion sensor readout
 dut = Dut('sensirionEKH4_pyserial.yaml')
 dut.init()
-print dut['Thermohygrometer'].get_temperature()
-print dut['Thermohygrometer'].get_humidity()
-print dut['Thermohygrometer'].get_dew_point()
+print(dut['Thermohygrometer'].get_temperature())
+print(dut['Thermohygrometer'].get_humidity())
+print(dut['Thermohygrometer'].get_dew_point())
 
 # Binder MK 53 control
 dut = Dut('binderMK53_pyserial.yaml')
 dut.init()
-print dut['Climatechamber'].get_temperature()
-print dut['Climatechamber'].get_door_open()
-print dut['Climatechamber'].get_mode()
+print(dut['Climatechamber'].get_temperature())
+print(dut['Climatechamber'].get_door_open())
+print(dut['Climatechamber'].get_mode())
 temperature_target = dut['Climatechamber'].get_temperature_target()
 dut['Climatechamber'].set_temperature(temperature_target)
 
 # Weiss SB 22 control
 dut = Dut('WeissSB22_pyserial.yaml')
 dut.init()
-print dut['Climatechamber'].get_temperature()
-print dut['Climatechamber'].get_digital_ch()
+print(dut['Climatechamber'].get_temperature())
+print(dut['Climatechamber'].get_digital_ch())
 temperature_target = dut['Climatechamber'].get_temperature_target()
 dut['Climatechamber'].set_temperature(temperature_target)

--- a/examples/lx9/host/lx9.py
+++ b/examples/lx9/host/lx9.py
@@ -5,6 +5,7 @@
 # ------------------------------------------------------------
 #
 
+from __future__ import print_function
 import yaml
 import time
 import numpy as np
@@ -64,7 +65,7 @@ class Pixel(Dut):
         self['SEQ']['SHIFT_IN'][0:px_size] = self['PIXEL_REG'][:] # this will be shifted out
         self['SEQ']['PIXEL_SHIFT_EN'][0:px_size] = bitarray( px_size * '1') #this is to enable clock
         
-        print 'px_size', px_size
+        print('px_size', px_size)
         
         
         self._run_seq(px_size+1) #add 1 bit more so there is 0 at the end other way will stay high
@@ -85,7 +86,7 @@ class Pixel(Dut):
             
             while not self['SEQ'].get_done():
                 #time.sleep(0.1)
-                print "Wait for done..."
+                print("Wait for done...")
 
     def _clear_strobes(self):
         """
@@ -99,7 +100,7 @@ class Pixel(Dut):
         self['SEQ']['PIXEL_SHIFT_EN'].setall(False)
         self['SEQ']['INJECTION'].setall(False)
 
-print "Start"
+print("Start")
 
 stream = open("lx9.yaml", 'r')
 cnfg = yaml.load(stream)
@@ -139,7 +140,7 @@ chip['GLOBAL_REG']['PrmpVbnFol'] = 0# size = 8
 chip['GLOBAL_REG']['vth'] = 0# size = 8
 chip['GLOBAL_REG']['PrmpVbf'] = 0# size = 8
 
-print "program global register..."
+print("program global register...")
 chip.program_global_reg()
     
 #settings for pixel register (to input into pixel SR)
@@ -147,26 +148,26 @@ chip.program_global_reg()
 # or a bitarray (of the form bitarray("10101100")).
 
 chip['PIXEL_REG'][:] = bitarray('1111111010001100'*8)
-print chip['PIXEL_REG']
+print(chip['PIXEL_REG'])
 #chip['PIXEL_REG'][0] = 0
 
-print "program pixel register..."
+print("program pixel register...")
 chip.program_pixel_reg()
 
 time.sleep(0.5)
 # Get output size in bytes
-print "chip['DATA'].get_FIFO_SIZE() = ", chip['DATA'].get_FIFO_SIZE()
+print("chip['DATA'].get_FIFO_SIZE() = ", chip['DATA'].get_FIFO_SIZE())
 
 rxd = chip['DATA'].get_data() #get data from sram fifo
-print rxd
+print(rxd)
 
 data0 = rxd.astype(np.uint8) # Change type to unsigned int 8 bits and take from rxd only the last 8 bits
 data1 = np.right_shift(rxd, 8).astype(np.uint8) # Rightshift rxd 8 bits and take again last 8 bits
 data = np.reshape(np.vstack((data1, data0)), -1, order='F') # data is now a 1 dimensional array of all bytes read from the FIFO
 bdata = np.unpackbits(data)
 
-print "data = ", data
-print "bdata = ", bdata 
+print("data = ", data)
+print("bdata = ", bdata) 
     
 
 

--- a/examples/mio_pixel/pixel.py
+++ b/examples/mio_pixel/pixel.py
@@ -6,6 +6,7 @@
 #
 
 
+from __future__ import print_function
 import time
 
 import numpy as np
@@ -151,7 +152,7 @@ if __name__ == "__main__":
     chip.program_pixel_reg()
 
     # Get output size in bytes
-    print("chip['DATA'].get_FIFO_SIZE() = ", chip['DATA'].get_FIFO_SIZE())
+    print(("chip['DATA'].get_FIFO_SIZE() = ", chip['DATA'].get_FIFO_SIZE()))
 
     # Get output in bytes
     print("chip['DATA'].get_data()")
@@ -162,5 +163,5 @@ if __name__ == "__main__":
     data = np.reshape(np.vstack((data1, data0)), -1, order='F')  # data is now a 1 dimensional array of all bytes read from the FIFO
     bdata = np.unpackbits(data)
 
-    print("data = ", data)
-    print("bdata = ", bdata)
+    print(("data = ", data))
+    print(("bdata = ", bdata))

--- a/examples/mio_sram_test/sram_test.py
+++ b/examples/mio_sram_test/sram_test.py
@@ -4,6 +4,7 @@
 # ------------------------------------------------------------
 #
 
+from __future__ import print_function
 import numpy as np
 
 from basil.dut import Dut
@@ -89,6 +90,6 @@ def test_register(count=10000):
 
 
 if __name__ == "__main__":
-    print 'test_register ...', 'errors:', test_register()
-    print 'test_direct ...', 'errors:', test_direct()
-    print 'test_sram ...', 'errors:', test_sram()
+    print('test_register ...', 'errors:', test_register())
+    print('test_direct ...', 'errors:', test_direct())
+    print('test_sram ...', 'errors:', test_sram())

--- a/examples/mmc3_eth/test/test_mmc3_eth.py
+++ b/examples/mmc3_eth/test/test_mmc3_eth.py
@@ -6,6 +6,7 @@
 # SiLab, Institute of Physics, University of Bonn
 # ------------------------------------------------------------
 #
+from __future__ import print_function
 import unittest
 import os, sys
 import time
@@ -107,7 +108,7 @@ class TestSimMMC3Eth(unittest.TestCase):
                 break
 
         total_len_bits = total_len*32   #32-bit ints to bits
-        print ('Bits received:', total_len_bits, '  data rate:', round((total_len_bits/1e6/testduration),2), ' Mbit/s')
+        print(('Bits received:', total_len_bits, '  data rate:', round((total_len_bits/1e6/testduration),2), ' Mbit/s'))
 
         self.chip['GPIO_LED']['LED'] = 0x00  #stop data source
         self.chip['GPIO_LED'].write()

--- a/examples/register_example/simple_register_example.py
+++ b/examples/register_example/simple_register_example.py
@@ -4,12 +4,13 @@
 # ------------------------------------------------------------
 #
 
+from __future__ import print_function
 from basil.dut import Dut
 
 chip = Dut("simple_register_example.yaml")
 
-print(chip['TEST'])
-print(chip['REG'])
+print((chip['TEST']))
+print((chip['REG']))
 
 # chip['REG'][0] = 1
 chip['REG']['VPULSE'][5] = 1
@@ -22,9 +23,9 @@ chip['REG']['COLUMN'][0]['EnR'] = 1
 chip['REG']['COLUMN'][0]['DACR'] = 3
 
 chip['REG']['VINJECT'] = 3
-print(chip['REG'])
+print((chip['REG']))
 
 chip['REG']['VINJECT'][0] = 1
-print(chip['REG'])
+print((chip['REG']))
 
-print('VINJECT', str(chip['REG']['VINJECT']))
+print(('VINJECT', str(chip['REG']['VINJECT'])))


### PR DESCRIPTION
Add partially missing Python 3 compatibility for:
- print function
- int --> long

Other needed changes have been checked for using `python-modernize`.