### PR TITLE
Py3k string fixes

### DIFF
--- a/basil/HL/binder_mk53.py
+++ b/basil/HL/binder_mk53.py
@@ -119,7 +119,7 @@ class binderMK53(HardwareLayer):
             raise RuntimeWarning('Checksum of read data wrong')
         n_words = n_bytes >> 1
         words = []
-        for word in xrange(n_words):
+        for word in range(n_words):
             words.extend(struct.unpack('>H', msgbytes[3 + word * 2:5 + word * 2]))
         return words
 
@@ -168,8 +168,8 @@ class binderMK53(HardwareLayer):
     def _calc_crc16(self, msg):
         crc = 0xffff
         for byte in msg:
-            crc ^= ord(byte)
-            for _ in xrange(8):  # loop bits
+            crc ^= byte
+            for _ in range(8):  # loop bits
                 sbit = crc & 1
                 crc >>= 1
                 crc ^= sbit * 0xA001

--- a/basil/HL/weiss_sb22.py
+++ b/basil/HL/weiss_sb22.py
@@ -131,7 +131,7 @@ class weissSB22(HardwareLayer):
 
     def _calc_crc(self, msg):
         ASCII = "0123456789ABCDEF"
-        mod_256 = (-(sum(ord(i) for i in msg) % 256) & 0xFF)
+        mod_256 = (-(sum(i for i in msg) % 256) & 0xFF)
         lword = (mod_256 & 0xF0) >> 4
         hword = mod_256 & 0x0F
         return ASCII[lword] + ASCII[hword]

--- a/basil/TL/Serial.py
+++ b/basil/TL/Serial.py
@@ -47,7 +47,7 @@ class Serial(TransferLayer):
     def read(self, size=None):
         if size is None:
             return self._readline()
-        return self._port.read(size)
+        return bytearray(self._port.read(size))
 
     def query(self, data):
         if self._port.inWaiting():
@@ -71,4 +71,4 @@ class Serial(TransferLayer):
             data += character
             if not character:
                 break
-        return bytes(data)
+        return data

--- a/basil/TL/SiTcp.py
+++ b/basil/TL/SiTcp.py
@@ -198,8 +198,8 @@ class SiTcp(SiTransferLayer):
                 if rlist:
                     # Read just enough for the header,
                     # remaining meassge data is lost.
-                    ack = self._sock_udp.recv(3)
-                    logger.warning('SiTcp:_write_single - Pending data before send - Message ID: current: %d, read: %d' % (self.RBCP_ID, ord(ack[2])))
+                    ack = bytearray(self._sock_udp.recv(3))
+                    logger.warning('SiTcp:_write_single - Pending data before send - Message ID: current: %d, read: %d' % (self.RBCP_ID, ack[2]))
                 else:
                     break
             retry_write_cnt += 1
@@ -229,8 +229,8 @@ class SiTcp(SiTransferLayer):
                     else:
                         # Recv buffer needs to be longer than message size,
                         # otherwise remaining message data is not read out and is lost.
-                        ack = self._sock_udp.recv(1024)
-                        if ord(ack[2]) != self.RBCP_ID:
+                        ack = bytearray(self._sock_udp.recv(1024))
+                        if ack[2] != self.RBCP_ID:
                             if retry_read_cnt <= self.UDP_RETRANSMIT_CNT:
                                 logger.warning('SiTcp:_write_single - Wrong ID - Retry...')
                                 continue
@@ -250,15 +250,15 @@ class SiTcp(SiTransferLayer):
                                 raise IOError('SiTcp:_write_single - Data error - expected: %s, read: %s' % (data, array('B', ack)[8:]))
                         if len(ack) != len(request):
                             raise IOError('SiTcp:_write_single - Wrong message size')
-                        if (0x0f & ord(ack[1])) != 0x8:
+                        if (0x0f & ack[1]) != 0x8:
                             raise IOError('SiTcp:_write_single - Bus error')
                         while True:
                             rlist, _, _ = select.select([self._sock_udp], [], [], 0.0)
                             if rlist:
                                 # Read just enough for the header,
                                 # remaining meassge data is lost.
-                                ack = self._sock_udp.recv(3)
-                                logger.warning('SiTcp:_write_single - Pending data after recv - Message ID: current: %d, read: %d' % (self.RBCP_ID, ord(ack[2])))
+                                ack = bytearray(self._sock_udp.recv(3))
+                                logger.warning('SiTcp:_write_single - Pending data after recv - Message ID: current: %d, read: %d' % (self.RBCP_ID, ack[2]))
                             else:
                                 break
                         return
@@ -301,8 +301,8 @@ class SiTcp(SiTransferLayer):
                 if rlist:
                     # Read just enough for the header,
                     # remaining meassge data is lost.
-                    ack = self._sock_udp.recv(3)
-                    logger.warning('SiTcp:_read_single - Pending data before send - Message ID: current: %d, read: %d' % (self.RBCP_ID, ord(ack[2])))
+                    ack = bytearray(self._sock_udp.recv(3))
+                    logger.warning('SiTcp:_read_single - Pending data before send - Message ID: current: %d, read: %d' % (self.RBCP_ID, ack[2]))
                 else:
                     break
             retry_write_cnt += 1
@@ -332,8 +332,8 @@ class SiTcp(SiTransferLayer):
                     else:
                         # Recv buffer needs to be longer than message size,
                         # otherwise remaining message data is not read out and is lost.
-                        ack = self._sock_udp.recv(1024)
-                        if ord(ack[2]) != self.RBCP_ID:
+                        ack = bytearray(self._sock_udp.recv(1024))
+                        if ack[2] != self.RBCP_ID:
                             if retry_read_cnt <= self.UDP_RETRANSMIT_CNT:
                                 logger.warning('SiTcp:_read_single - Wrong ID - Retry...')
                                 continue
@@ -353,15 +353,15 @@ class SiTcp(SiTransferLayer):
                                 raise IOError('SiTcp:_read_single - Data error - expected: %s, read: %s' % (request[3:], array('B', ack)[8:]))
                         if len(ack) != size + 8:
                             raise IOError('SiTcp:_read_single - Wrong message size')
-                        if (0x0f & ord(ack[1])) != 0x8:
+                        if (0x0f & ack[1]) != 0x8:
                             raise IOError('SiTcp:_read_single - Bus error')
                         while True:
                             rlist, _, _ = select.select([self._sock_udp], [], [], 0.0)
                             if rlist:
                                 # Read just enough for the header,
                                 # remaining meassge data is lost.
-                                ack = self._sock_udp.recv(3)
-                                logger.warning('SiTcp:_read_single - Pending data after recv - Message ID: current: %d, read: %d' % (self.RBCP_ID, ord(ack[2])))
+                                ack = bytearray(self._sock_udp.recv(3))
+                                logger.warning('SiTcp:_read_single - Pending data after recv - Message ID: current: %d, read: %d' % (self.RBCP_ID, ack[2]))
                             else:
                                 break
                         return array('B', ack[8:])
@@ -403,8 +403,8 @@ class SiTcp(SiTransferLayer):
                 time_read = time()
                 if rlist:
                     with self._tcp_lock:
-                        data = self._sock_tcp.recv(1024 * 8)
-                        self._tcp_read_buff.extend(array('B', data))
+                        data = bytearray(self._sock_tcp.recv(1024 * 8))
+                        self._tcp_read_buff.extend(data)
             except AttributeError:
                 pass
 


### PR DESCRIPTION
The `socket` library returns `binary arrays` under Python 3 and  `strings` under Python 2. This is treated here.

The `SiTCP` module was tested with hardware using `bdaq53` with Python 2 and Python 3.

The fridges HL was also changed. Not tested but also not really important.