### PR TITLE
FIX: Fix encoding error in Serial TL due to python3

### DIFF
--- a/basil/HL/scpi.py
+++ b/basil/HL/scpi.py
@@ -41,7 +41,7 @@ class scpi(HardwareLayer):
         except IOError:
             raise RuntimeError('Cannot find a device description for ' + self._init['device'] + '. Consider adding it!')
         if 'identifier' in self._scpi_commands and self._scpi_commands['identifier']:
-            name = self.get_name()
+            name = str(self.get_name())
             if self._scpi_commands['identifier'] not in name:
                 raise RuntimeError('Wrong device description (' + self._init['device'] + ') loaded for ' + name)
 

--- a/basil/TL/Serial.py
+++ b/basil/TL/Serial.py
@@ -40,9 +40,9 @@ class Serial(TransferLayer):
 
     def write(self, data):
         if self.write_termination is None:
-            self._port.write(bytes(data))
+            self._port.write(bytes(data, 'ascii'))
         else:
-            self._port.write(bytes(data + self.write_termination))
+            self._port.write(bytes(data + self.write_termination, 'ascii'))
 
     def read(self, size=None):
         if size is None:


### PR DESCRIPTION
This PR fixes the encoding error in Serial TL that was coming up with the switch to python 3