### PR TITLE
ENH: encapsulate tobytes call for python 2/3 compatibility

### DIFF
--- a/basil/HL/RegisterHardwareLayer.py
+++ b/basil/HL/RegisterHardwareLayer.py
@@ -12,6 +12,7 @@ import array
 from collections import namedtuple
 from six import integer_types
 
+from basil.utils.utils import tobytes
 from basil.utils.BitLogic import BitLogic
 from basil.HL.HardwareLayer import HardwareLayer
 
@@ -104,7 +105,7 @@ class RegisterHardwareLayer(HardwareLayer):
         else:
             ret = self._intf.read(self._base_addr + addr + div_offset, size=div_size)
             reg = BitLogic()
-            reg.frombytes(ret.tostring())
+            reg.frombytes(tobytes(ret))
         reg[size + mod_offset - 1:mod_offset] = value
         self._intf.write(self._base_addr + addr + div_offset, data=array.array('B', reg.tobytes()))
 
@@ -131,7 +132,7 @@ class RegisterHardwareLayer(HardwareLayer):
             div_size += 1
         ret = self._intf.read(self._base_addr + addr + div_offset, size=div_size)
         reg = BitLogic()
-        reg.frombytes(ret.tostring())
+        reg.frombytes(tobytes(ret))
         return reg[size + mod_offset - 1:mod_offset].tovalue()
 
     def set_bytes(self, data, addr, **kwargs):

--- a/basil/RL/StdRegister.py
+++ b/basil/RL/StdRegister.py
@@ -171,7 +171,7 @@ class StdRegister(RegisterLayer):
 
     def frombytes(self, value):
         bl_value = BitLogic()
-        bl_value.frombytes(array.array('B', value)[::-1].tostring())
+        bl_value.frombytes(utils.tobytes(array.array('B', value)[::-1]))
         self._deconstruct_reg(bl_value[self._conf['size']:])
 
     def get_configuration(self):

--- a/basil/utils/utils.py
+++ b/basil/utils/utils.py
@@ -25,7 +25,7 @@ def logging(fn):
 def bitvector_to_byte_array(bitvector):
     bsize = len(bitvector)
     size_bytes = int(((bsize - 1) / 8) + 1)
-    bs = array.array('B', bitvector.vector.tostring())[0:size_bytes]
+    bs = tobytes(array.array('B', bitvector.vector))[0:size_bytes]
     bitstream_swap = ''
     lsbits = lambda b: (b * 0x0202020202 & 0x010884422010) % 1023
     for b in bs:
@@ -39,3 +39,13 @@ def bitarray_to_byte_array(bitarr):
     bs = np.fromstring(ba.tobytes(), dtype=np.uint8)  # byte padding happens here, bitarray.tobytes()
     bs = (bs * 0x0202020202 & 0x010884422010) % 1023
     return array.array('B', bs.astype(np.uint8))
+
+# Python 2/3 compatibility function for array.tobytes function
+try:
+    array.tobytes
+except AttributeError:
+    def tobytes(v):
+        return v.tostring()
+else:
+    def tobytes(v):
+        return v.tobytes()

--- a/basil/utils/utils.py
+++ b/basil/utils/utils.py
@@ -43,9 +43,9 @@ def bitarray_to_byte_array(bitarr):
 # Python 2/3 compatibility function for array.tobytes function
 try:
     array.tobytes
-except AttributeError:
+except AttributeError:  # Python 2
     def tobytes(v):
         return v.tostring()
-else:
+else:  # Python 3
     def tobytes(v):
         return v.tobytes()


### PR DESCRIPTION
Otherwise insane amount of:
```
DeprecationWarning: tostring() is deprecated. Use tobytes() instead.
```
warnings
