### PR TITLE
Keep python 2 compatibility in Serial TL

### DIFF
--- a/basil/HL/tti_ql355tp.py
+++ b/basil/HL/tti_ql355tp.py
@@ -12,7 +12,7 @@ from basil.HL.RegisterHardwareLayer import HardwareLayer
 
 
 class ttiQl355tp(HardwareLayer):
-    ''' HL for the TTi QL3335TP.
+    ''' HL for the TTi QL355TP.
     '''
 
     def __init__(self, intf, conf):
@@ -46,7 +46,7 @@ class ttiQl355tp(HardwareLayer):
             cmd = "OP%d %d" % (channel, int(on))
         self.write(cmd)
 
-    def get_info(self):
+    def get_name(self):
         return self.ask("*IDN?")
 
     def get_current(self, channel):

--- a/basil/HL/tti_ql355tp.yaml
+++ b/basil/HL/tti_ql355tp.yaml
@@ -1,4 +1,4 @@
-# Device description for the TTi QL335 Power Supply.
+# Device description for the TTi QL355 Power Supply.
 identifier : QL355TP
 on : OPALL 1
 off : OPALL 0

--- a/examples/lab_devices/scpi_devices.py
+++ b/examples/lab_devices/scpi_devices.py
@@ -39,10 +39,10 @@ dut['Pulser'].set_voltage(0., 1., unit='V')
 print(dut['Pulser'].get_voltage(0, unit='mV'), 'mV')
 
 # Example for device with multiple channels
-dut = Dut('ttiql335tp_pyvisa.yaml')
+dut = Dut('ttiql355tp.yaml')
 dut.init()
-dut['PowerSupply'].get_name()
-dut['PowerSupply'].get_voltage(channel=1)
+print(dut['PowerSupply'].get_name())
+print(dut['PowerSupply'].get_voltage(channel=1))
 
 # Talk to a Keithley device via GPIB using NI VISA
 dut = Dut('keithley2000_pyvisa.yaml')

--- a/examples/lab_devices/ttiql355tp.yaml
+++ b/examples/lab_devices/ttiql355tp.yaml
@@ -13,6 +13,6 @@ transfer_layer:
         bytesize : 8
 
 hw_drivers:
-  - name      : power
+  - name      : PowerSupply
     type      : tti_ql355tp
     interface : Serial

--- a/examples/lab_devices/ttiql355tp_pyvisa.yaml
+++ b/examples/lab_devices/ttiql355tp_pyvisa.yaml
@@ -10,4 +10,4 @@ hw_drivers:
     type      : scpi
     interface : Visa
     init      :
-        device : TTi QL335TP
+        device : TTi QL355TP


### PR DESCRIPTION
With the last PR, python 3 was supported in Serial TL, but it broke python 2 backwards compatibility. This PR restores compatibility with py2 while keeping py3 working as well.

Also cleaned up the TTi mess where it was wrongly named QL335TP instead of QL355TP in some places.