### PR TITLE
MAINT: remove callable import warning

### DIFF
--- a/basil/RL/RegisterLayer.py
+++ b/basil/RL/RegisterLayer.py
@@ -5,7 +5,10 @@
 # ------------------------------------------------------------
 #
 
-from collections import Callable
+try:
+    from collections.abc import Callable  # noqa
+except ImportError:
+    from collections import Callable  # noqa
 
 from basil.dut import Base
 


### PR DESCRIPTION
Remove callable warning under Python 3