### PR TITLE
ENH: Add channel parameter to sensirion_ekh4

### DIFF
--- a/basil/HL/sensirion_ekh4.py
+++ b/basil/HL/sensirion_ekh4.py
@@ -55,18 +55,21 @@ class sensirionEKH4(HardwareLayer):
                 answer.append(a)
         return answer
 
-    def get_temperature(self, min_val=-40, max_val=200):
+    def get_temperature(self, channel='all', min_val=-40, max_val=200):
         ret = self.ask(r"7e4700b87e")
         values = []
         for j in range(4):
             if ret[2 + 2 * j] == "7f" and ret[2 + 2 * j + 1] == "ff":
                 values.append(None)
             else:
-                values.append(self.cal_ret(
-                    ret[2 + 2 * j] + ret[2 + 2 * j + 1]))
-        return values
+                values.append(self.cal_ret(ret[2 + 2 * j] + ret[2 + 2 * j + 1]))
 
-    def get_humidity(self, min_val=0, max_val=100):
+        if channel == 'all':
+            return values
+        elif isinstance(channel, int):
+            return values[channel]
+
+    def get_humidity(self, channel='all', min_val=0, max_val=100):
         ret = self.ask(r"7e4600b97e")
         values = []
         for j in range(4):
@@ -75,9 +78,13 @@ class sensirionEKH4(HardwareLayer):
             else:
                 values.append(self.cal_ret(
                     ret[2 + 2 * j] + ret[2 + 2 * j + 1]))
-        return values
 
-    def get_dew_point(self, min_val=-40, max_val=100):
+        if channel == 'all':
+            return values
+        elif isinstance(channel, int):
+            return values[channel]
+
+    def get_dew_point(self, channel='all', min_val=-40, max_val=100):
         ret = self.ask(r"7e4800b77e")
         values = []
         for j in range(4):
@@ -86,7 +93,11 @@ class sensirionEKH4(HardwareLayer):
             else:
                 values.append(self.cal_ret(
                     ret[2 + 2 * j] + ret[2 + 2 * j + 1]))
-        return values
+
+        if channel == 'all':
+            return values
+        elif isinstance(channel, int):
+            return values[channel]
 
     def cal_ret(self, value):
         bits = 16

--- a/basil/HL/sensirion_ekh4.py
+++ b/basil/HL/sensirion_ekh4.py
@@ -64,7 +64,7 @@ class sensirionEKH4(HardwareLayer):
             else:
                 values.append(self.cal_ret(ret[2 + 2 * j] + ret[2 + 2 * j + 1]))
 
-        if channelis None:
+        if channel is None:
             return values
         return values[channel]
 
@@ -75,10 +75,9 @@ class sensirionEKH4(HardwareLayer):
             if ret[2 + 2 * j] == "7f" and ret[2 + 2 * j + 1] == "ff":
                 values.append(None)
             else:
-                values.append(self.cal_ret(
-                    ret[2 + 2 * j] + ret[2 + 2 * j + 1]))
+                values.append(self.cal_ret(ret[2 + 2 * j] + ret[2 + 2 * j + 1]))
 
-        if channelis None:
+        if channel is None:
             return values
         return values[channel]
 
@@ -89,10 +88,9 @@ class sensirionEKH4(HardwareLayer):
             if ret[2 + 2 * j] == "7f" and ret[2 + 2 * j + 1] == "ff":
                 values.append(None)
             else:
-                values.append(self.cal_ret(
-                    ret[2 + 2 * j] + ret[2 + 2 * j + 1]))
+                values.append(self.cal_ret(ret[2 + 2 * j] + ret[2 + 2 * j + 1]))
 
-        if channelis None:
+        if channel is None:
             return values
         return values[channel]
 

--- a/basil/HL/sensirion_ekh4.py
+++ b/basil/HL/sensirion_ekh4.py
@@ -55,7 +55,7 @@ class sensirionEKH4(HardwareLayer):
                 answer.append(a)
         return answer
 
-    def get_temperature(self, channel='all', min_val=-40, max_val=200):
+    def get_temperature(self, channel=None, min_val=-40, max_val=200):
         ret = self.ask(r"7e4700b87e")
         values = []
         for j in range(4):
@@ -64,12 +64,11 @@ class sensirionEKH4(HardwareLayer):
             else:
                 values.append(self.cal_ret(ret[2 + 2 * j] + ret[2 + 2 * j + 1]))
 
-        if channel == 'all':
+        if channelis None:
             return values
-        elif isinstance(channel, int):
-            return values[channel]
+        return values[channel]
 
-    def get_humidity(self, channel='all', min_val=0, max_val=100):
+    def get_humidity(self, channel=None, min_val=0, max_val=100):
         ret = self.ask(r"7e4600b97e")
         values = []
         for j in range(4):
@@ -79,12 +78,11 @@ class sensirionEKH4(HardwareLayer):
                 values.append(self.cal_ret(
                     ret[2 + 2 * j] + ret[2 + 2 * j + 1]))
 
-        if channel == 'all':
+        if channelis None:
             return values
-        elif isinstance(channel, int):
-            return values[channel]
+        return values[channel]
 
-    def get_dew_point(self, channel='all', min_val=-40, max_val=100):
+    def get_dew_point(self, channel=None, min_val=-40, max_val=100):
         ret = self.ask(r"7e4800b77e")
         values = []
         for j in range(4):
@@ -94,10 +92,9 @@ class sensirionEKH4(HardwareLayer):
                 values.append(self.cal_ret(
                     ret[2 + 2 * j] + ret[2 + 2 * j + 1]))
 
-        if channel == 'all':
+        if channelis None:
             return values
-        elif isinstance(channel, int):
-            return values[channel]
+        return values[channel]
 
     def cal_ret(self, value):
         bits = 16


### PR DESCRIPTION
This PR adds a `channel` parameter to the thre `get_` methods of the `sensirion_ekh4` HL. This enables using `FunctionalRegisters` to call each sensor connected to the Sensirion Multiplexer box as independent device.