### PR TITLE
Fix memory leak in SiTCP

### DIFF
--- a/basil/TL/SiTcp.py
+++ b/basil/TL/SiTcp.py
@@ -461,6 +461,9 @@ class SiTcp(SiTransferLayer):
         super(SiTcp, self).close()
         self._stop = True
         self._tcp_readout_thread.join()
+        # https://stackoverflow.com/questions/60487126/why-does-cpython-garbage-collection-with-threads-not-work
+        del self._tcp_readout_thread
+        del self._tcp_read_buff
         self._sock_udp.close()
         if self._init['tcp_connection']:
             self._sock_tcp.close()


### PR DESCRIPTION
When using a *dut* object with SiTCP TL an `array.array` object is created that is never garbage collected. This nice, simple example from  @michaeldaas shows this:
``` python
from pympler import muppy
import array
from basil.dut import Dut
configuration = {
    'transfer_layer': [{
        'name': 'intf',
        'type': 'SiTcp',
        'init': {
            'ip' : "192.168.10.12",
            'udp_port' : 4660,
            'tcp_port' : 24,
            'tcp_connection' : True
        }
    }],
    'hw_drivers': [{
        'name': 'FIFO',
        'type': 'sitcp_fifo',
        'interface': 'intf',
        'base_addr': 0x200000000,
        'base_data_addr': 0x100000000
    }]
}
for i in range(5):
    dut = Dut(configuration)
    dut.init()
    dut.close()
    all_objects = muppy.get_objects()
    my_types = muppy.filter(all_objects, Type=array.ArrayType)
    print('Iteration {}:'.format(i))
    for obj in my_types:
        print(obj)
```

To me, this behaviour is weird. I posted a question on [stackoverflow](https://stackoverflow.com/questions/60487126/why-does-cpython-garbage-collection-with-threads-not-work). Let's see. Nevertheless, this PR fixes the memory leak.