### PR TITLE
BUG: Fix memory address not increasing when sending multiple words

### DIFF
--- a/basil/HL/JtagMaster.py
+++ b/basil/HL/JtagMaster.py
@@ -8,6 +8,8 @@ import struct
 
 from basil.HL.RegisterHardwareLayer import RegisterHardwareLayer
 from basil.utils.BitLogic import BitLogic
+from bitarray import bitarray
+import numpy as np
 
 
 class JtagMaster(RegisterHardwareLayer):
@@ -102,7 +104,7 @@ class JtagMaster(RegisterHardwareLayer):
         self.SIZE = bit_number
 
         data_byte = self._bitlogic2bytes(data)
-        self.set_data(data_byte[::-1])
+        self.set_data(data_byte)
 
         self.WORD_COUNT = 1
         self.set_command("INSTRUCTION")
@@ -111,8 +113,7 @@ class JtagMaster(RegisterHardwareLayer):
             pass
 
         received_data = self.get_data(size=len(data_byte))
-        ret = self._bytes2bitlogic(received_data, bit_number)
-        rlist = self._split_bitlogic(ret, data)
+        rlist = self._bytes2bitlogic(received_data, bit_number, data)
 
         return rlist
 
@@ -131,7 +132,7 @@ class JtagMaster(RegisterHardwareLayer):
         self.WORD_COUNT = words
         if type(data[0]) == BitLogic:
             data_byte = self._bitlogic2bytes(data)
-            self.set_data(data_byte[::-1])
+            self.set_data(data_byte)
         else:
             data_byte = self._raw_data2bytes(data)
             self.set_data(data_byte)
@@ -141,8 +142,7 @@ class JtagMaster(RegisterHardwareLayer):
             pass
 
         received_data = self.get_data(size=len(data_byte))
-        ret = self._bytes2bitlogic(received_data, bit_number)
-        rlist = self._split_bitlogic(ret, data)
+        rlist = self._bytes2bitlogic(received_data, bit_number, data)
 
         return rlist
 
@@ -153,53 +153,47 @@ class JtagMaster(RegisterHardwareLayer):
         if type(data[0]) == BitLogic or type(data[0]) == str:
             pass
         else:
-            raise TypeError(
-                "Type of data not supported: got", type(data[0]), " and support only str and Bitlogic",
-            )
+            raise TypeError("Type of data not supported: got", type(data[0]), " and support only str and Bitlogic")
 
         bit_number = sum(len(x) for x in data)
         if bit_number <= self._mem_bytes * 8:
             pass
         else:
             raise ValueError("Size is too big for memory: got %d and memory is: %d" % (bit_number, self._mem_bytes * 8))
-        
+
         if words != 1 and bit_number % words != 0:
             raise ValueError("Number of bits doesn't match the number of words. %d bits remaining" % (bit_number % words))
 
         return bit_number
 
     def _bitlogic2bytes(self, data):
-        bitlogic_to_send = BitLogic()
-        size_dev = len(data)
-        for dev in range(size_dev):
-            bitlogic_to_send.extend(data[dev])
-        bitlogic_to_send.fill()
-        bitlogic_to_send.reverse()
-        data_byte = bitlogic_to_send.tobytes()
+        original_string = ""
+        for dev in range(len(data)):
+            device_string = data[dev].to01()
+            original_string += device_string[::-1]  # We want the original string of the Bitlogic, not the reversed one
+        data_bitarray = bitarray(original_string)
+        data_byte = data_bitarray.tobytes()
+
         return data_byte
 
-    def _bytes2bitlogic(self, data, bit_number):
-        ret = [BitLogic()]
-        for i in range(len(data)):
-            b = BitLogic.from_value(data[i], fmt="B")
-            b.reverse()
-            ret[0].extend(b)
-        return ret[0][bit_number - 1::]
+    def _bytes2bitlogic(self, data, bit_number, original_data):
+        data_byte = np.byte(data)
+        tmp = bitarray()
+        tmp.frombytes(data_byte.tobytes())
+        binary_string = tmp.to01()
 
-    def _split_bitlogic(self, data_to_split, original_data):
         rlist = []
         last_data_len = 0
         for i in original_data:
-            rlist.append(data_to_split[len(i) - 1 + last_data_len:last_data_len])
-            last_data_len = last_data_len + len(i)
+            rlist.append(BitLogic(binary_string[last_data_len:len(i) + last_data_len]))
+            last_data_len += len(i)
+
         return rlist
 
     def _raw_data2bytes(self, data):
         all_data = ""
         for i in data:
-            all_data = i + all_data
-        # inversion needed for JTAG
-        all_data = all_data[::-1]
+            all_data = all_data + i
         # pad with zero if not a multiple of 8
         if len(all_data) % 8 != 0:
             all_data = all_data + "0" * (8 - (len(all_data) % 8))

--- a/basil/firmware/modules/jtag_master/jtag_master_core.v
+++ b/basil/firmware/modules/jtag_master/jtag_master_core.v
@@ -165,7 +165,7 @@ reg [32:0] out_word_cnt;
 reg [32:0] reset_cnt;
 
 wire [13:0] memout_addrb;
-assign memout_addrb = (out_word_cnt * CONF_BIT_OUT) + out_bit_cnt;
+assign memout_addrb = (out_word_cnt * CONF_BIT_OUT) + CONF_BIT_OUT - 1 - out_bit_cnt;
 wire [10:0] memout_addra;
 assign memout_addra = (BUS_ADD-16);
 
@@ -185,7 +185,7 @@ blk_mem_gen_8_to_1_2k memout(
 wire [10:0] ADDRA_MIN;
 assign ADDRA_MIN = (BUS_ADD-16-MEM_BYTES);
 wire [13:0] ADDRB_MIN;
-assign ADDRB_MIN = (out_word_cnt * CONF_BIT_OUT) + out_bit_cnt - 1;
+assign ADDRB_MIN = (out_word_cnt * CONF_BIT_OUT) + CONF_BIT_OUT - out_bit_cnt;
 reg SEN_INT;
 
 blk_mem_gen_8_to_1_2k memin(

--- a/tests/test_SimJtagMaster.v
+++ b/tests/test_SimJtagMaster.v
@@ -86,7 +86,7 @@ jtag_master #(
     .BASEADDR(JTAGM_BASEADDR),
     .HIGHADDR(JTAGM_HIGHADDR),
     .ABUSWIDTH(ABUSWIDTH),
-    .MEM_BYTES(16)
+    .MEM_BYTES(2000)
 ) i_jtag_master (
     .BUS_CLK(BUS_CLK),
     .BUS_RST(BUS_RST),

--- a/tests/test_SimJtagMaster.v
+++ b/tests/test_SimJtagMaster.v
@@ -109,8 +109,8 @@ wire td_int;
 wire [31:0] debug_reg1, debug_reg2;
 
 wire wr_fifo;
-jtag_tap i_jtag_tap1(.jtag_tms_i(TMS), .jtag_tck_i(TCK), .jtag_trstn_i(1'b1), .jtag_tdi_i(TDI), .jtag_tdo_o(td_int), .debug_reg(debug_reg2));
-jtag_tap i_jtag_tap2(.jtag_tms_i(TMS), .jtag_tck_i(TCK), .jtag_trstn_i(1'b1), .jtag_tdi_i(td_int), .jtag_tdo_o(TDO), .debug_reg(debug_reg1), .is_tap_state_update_dr_o(wr_fifo));
+jtag_tap i_jtag_tap1(.jtag_tms_i(TMS), .jtag_tck_i(TCK), .jtag_trstn_i(1'b1), .jtag_tdi_i(TDI), .jtag_tdo_o(td_int), .debug_reg(debug_reg1));
+jtag_tap i_jtag_tap2(.jtag_tms_i(TMS), .jtag_tck_i(TCK), .jtag_trstn_i(1'b1), .jtag_tdi_i(td_int), .jtag_tdo_o(TDO), .debug_reg(debug_reg2), .is_tap_state_update_dr_o(wr_fifo));
 
 wire D1_F1;
 wire [5:0] D1_F2;
@@ -178,7 +178,7 @@ bram_fifo #(
 
     .FIFO_READ_NEXT_OUT(),
     .FIFO_EMPTY_IN(~fifo_strobe),
-    .FIFO_DATA(debug_reg2),
+    .FIFO_DATA(debug_reg1),
 
     .FIFO_NOT_EMPTY(),
     .FIFO_FULL(),
@@ -202,7 +202,7 @@ bram_fifo #(
 
     .FIFO_READ_NEXT_OUT(),
     .FIFO_EMPTY_IN(~fifo_strobe),
-    .FIFO_DATA(debug_reg1),
+    .FIFO_DATA(debug_reg2),
 
     .FIFO_NOT_EMPTY(),
     .FIFO_FULL(),


### PR DESCRIPTION
I have also added a new test that write data directly into module memory without using the scan_dr function to test multiple word writing.