### PR TITLE
New split bus interface 2 / Verilator simulation support

### DIFF
--- a/basil/firmware/modules/gpio/gpio.v
+++ b/basil/firmware/modules/gpio/gpio.v
@@ -4,6 +4,8 @@
  * SiLab, Institute of Physics, University of Bonn
  * ------------------------------------------------------------
  */
+`timescale 1ps/1ps
+`default_nettype none
 
 module gpio #(
     parameter BASEADDR = 16'h0000,

--- a/basil/firmware/modules/gpio/gpio_sbus.v
+++ b/basil/firmware/modules/gpio/gpio_sbus.v
@@ -4,6 +4,8 @@
  * SiLab, Institute of Physics, University of Bonn
  * ------------------------------------------------------------
  */
+`timescale 1ps/1ps
+`default_nettype none
 
 module gpio_sbus #(
     parameter BASEADDR = 16'h0000,

--- a/basil/firmware/modules/utils/bus_to_ip.v
+++ b/basil/firmware/modules/utils/bus_to_ip.v
@@ -29,7 +29,9 @@ module bus_to_ip
 );
 
 wire CS;
+/* verilator lint_off UNSIGNED */
 assign CS = (BUS_ADD >= BASEADDR && BUS_ADD <= HIGHADDR);
+/* verilator lint_on UNSIGNED */
 
 assign IP_ADD = CS ? BUS_ADD - BASEADDR : {ABUSWIDTH{1'b0}};
 assign IP_RD = CS ? BUS_RD : 1'b0;

--- a/basil/firmware/modules/utils/sbus_to_ip.v
+++ b/basil/firmware/modules/utils/sbus_to_ip.v
@@ -28,7 +28,9 @@ module sbus_to_ip
 );
 
 wire CS;
+/* verilator lint_off UNSIGNED */
 assign CS = (BUS_ADD >= BASEADDR && BUS_ADD <= HIGHADDR);
+/* verilator lint_on UNSIGNED */
 
 assign IP_ADD = CS ? BUS_ADD - BASEADDR : {ABUSWIDTH{1'b0}};
 assign IP_RD = CS ? BUS_RD : 1'b0;

--- a/basil/utils/sim/BasilSbusDriver.py
+++ b/basil/utils/sim/BasilSbusDriver.py
@@ -1,0 +1,134 @@
+#
+# ------------------------------------------------------------
+# Copyright (c) All rights reserved
+# SiLab, Institute of Physics, University of Bonn
+# ------------------------------------------------------------
+#
+# Initial version by Chris Higgs <chris.higgs@potentialventures.com>
+#
+
+# pylint: disable=pointless-statement, expression-not-assigned
+
+
+import cocotb
+from cocotb.binary import BinaryValue
+from cocotb.triggers import RisingEdge
+from cocotb.drivers import BusDriver
+from cocotb.clock import Clock
+
+
+class BasilSbusDriver(BusDriver):
+    """Abastract away interactions with the control bus.
+    """
+    _signals = ["BUS_CLK", "BUS_RST", "BUS_DATA_IN", "BUS_DATA_OUT", "BUS_ADD", "BUS_RD", "BUS_WR"]
+    _optional_signals = ["BUS_BYTE_ACCESS"]
+
+    def __init__(self, entity):
+        BusDriver.__init__(self, entity, "", entity.BUS_CLK)
+
+        # Create an appropriately sized high-impedance value
+        self._high_impedance = BinaryValue(n_bits=len(self.bus.BUS_DATA_IN))
+        self._high_impedance.binstr = "Z" * len(self.bus.BUS_DATA_IN)
+
+        # Create an appropriately sized high-impedance value
+        self._x = BinaryValue(n_bits=len(self.bus.BUS_ADD))
+        self._x.binstr = "x" * len(self.bus.BUS_ADD)
+
+        self._has_byte_acces = False
+
+        # Kick off a clock generator
+        cocotb.fork(Clock(self.clock, 5000).start())
+
+    async def init(self):
+        # Defaults
+        self.bus.BUS_RST <= 1
+        self.bus.BUS_RD <= 0
+        self.bus.BUS_WR <= 0
+        self.bus.BUS_ADD <= self._x
+        self.bus.BUS_DATA_IN <= self._high_impedance
+
+        for _ in range(8):
+            await RisingEdge(self.clock)
+
+        self.bus.BUS_RST <= 0
+
+        for _ in range(2):
+            await RisingEdge(self.clock)
+
+        # why this does not work? hasattr(self.bus, 'BUS_BYTE_ACCESS'):
+        try:
+            getattr(self.bus, 'BUS_BYTE_ACCESS')
+        except Exception:
+            self._has_byte_acces = False
+        else:
+            self._has_byte_acces = True
+
+    async def read(self, address, size):
+        result = []
+
+        self.bus.BUS_ADD <= self._x
+        self.bus.BUS_DATA_IN <= self._high_impedance
+        self.bus.BUS_RD <= 0
+
+        await RisingEdge(self.clock)
+
+        byte = 0
+        while(byte <= size):
+            if(byte == size):
+                self.bus.BUS_RD <= 0
+            else:
+                self.bus.BUS_RD <= 1
+
+            self.bus.BUS_ADD <= address + byte
+
+            await RisingEdge(self.clock)
+
+            if(byte != 0):
+                if(self._has_byte_acces and self.bus.BUS_BYTE_ACCESS.value.integer == 0):
+                    result.append(self.bus.BUS_DATA_OUT.value.integer & 0x000000ff)
+                    result.append((self.bus.BUS_DATA_OUT.value.integer & 0x0000ff00) >> 8)
+                    result.append((self.bus.BUS_DATA_OUT.value.integer & 0x00ff0000) >> 16)
+                    result.append((self.bus.BUS_DATA_OUT.value.integer & 0xff000000) >> 24)
+                else:
+                    #    result.append(self.bus.BUS_DATA_OUT.value[24:31].integer & 0xff)
+                    if len(self.bus.BUS_DATA_OUT.value) == 8:
+                        result.append(self.bus.BUS_DATA_OUT.value.integer & 0xff)
+                    else:
+                        result.append(self.bus.BUS_DATA_OUT.value[24:31].integer & 0xff)
+
+            if(self._has_byte_acces and self.bus.BUS_BYTE_ACCESS.value.integer == 0):
+                byte += 4
+            else:
+                byte += 1
+
+        self.bus.BUS_ADD <= self._x
+        self.bus.BUS_DATA_IN <= self._high_impedance
+        self.bus.BUS_RD <= 0
+
+        await RisingEdge(self.clock)
+
+        return result
+
+    async def write(self, address, data):
+
+        self.bus.BUS_ADD <= self._x
+        self.bus.BUS_DATA_IN <= self._high_impedance
+        self.bus.BUS_WR <= 0
+
+        await RisingEdge(self.clock)
+
+        for index, byte in enumerate(data):
+            self.bus.BUS_DATA_IN <= byte
+            self.bus.BUS_WR <= 1
+            self.bus.BUS_ADD <= address + index
+
+            await RisingEdge(self.clock)
+
+        if(self._has_byte_acces and self.bus.BUS_BYTE_ACCESS.value.integer == 0):
+            raise NotImplementedError("BUS_BYTE_ACCESS for write to be implemented.")
+
+        self.bus.BUS_ADD <= self._x
+        self.bus.BUS_DATA_IN <= self._high_impedance
+        self.bus.BUS_WR <= 0
+
+        await RisingEdge(self.clock)

--- a/basil/utils/sim/SiLibUsbBusDriver.py
+++ b/basil/utils/sim/SiLibUsbBusDriver.py
@@ -16,7 +16,6 @@ import cocotb
 from cocotb.binary import BinaryValue
 from cocotb.triggers import RisingEdge, ReadOnly, Timer
 from cocotb.drivers import BusDriver
-from cocotb.result import ReturnValue
 from cocotb.clock import Clock
 
 
@@ -36,19 +35,18 @@ class SiLibUsbBusDriver(BusDriver):
     def __init__(self, entity):
         BusDriver.__init__(self, entity, "", entity.FCLK_IN)
 
-        # Create an appropriately sized high-impedence value
-        self._high_impedence = BinaryValue(n_bits=len(self.bus.BUS_DATA))
-        self._high_impedence.binstr = "Z" * len(self.bus.BUS_DATA)
+        # Create an appropriately sized high-impedance value
+        self._high_impedance = BinaryValue(n_bits=len(self.bus.BUS_DATA))
+        self._high_impedance.binstr = "Z" * len(self.bus.BUS_DATA)
 
-        # Create an appropriately sized high-impedence value
+        # Create an appropriately sized high-impedance value
         self._x = BinaryValue(n_bits=16)
         self._x.binstr = "x" * 16
 
         # Kick off a clock generator
         cocotb.fork(Clock(self.clock, 20800).start())
 
-    @cocotb.coroutine
-    def init(self):
+    async def init(self):
         # Defaults
         # self.bus.BUS_RST<= 1
         self.bus.RD_B <= 1
@@ -57,15 +55,14 @@ class SiLibUsbBusDriver(BusDriver):
         self.bus.FREAD <= 0
         self.bus.FSTROBE <= 0
         self.bus.FMODE <= 0
-        self.bus.BUS_DATA <= self._high_impedence
-        self.bus.FD <= self._high_impedence
+        self.bus.BUS_DATA <= self._high_impedance
+        self.bus.FD <= self._high_impedance
 
         # wait for reset
         for _ in range(200):
-            yield RisingEdge(self.clock)
+            await RisingEdge(self.clock)
 
-    @cocotb.coroutine
-    def read(self, address, size):
+    async def read(self, address, size):
         result = []
         if(address >= self.BASE_ADDRESS_I2C and address < self.HIGH_ADDRESS_I2C):
             self.entity._log.warning("I2C address space supported in simulation!")
@@ -73,109 +70,105 @@ class SiLibUsbBusDriver(BusDriver):
                 result.append(0)
         elif(address >= self.BASE_ADDRESS_EXTERNAL and address < self.HIGH_ADDRESS_EXTERNAL):
             for byte in range(size):
-                val = yield self.read_external(address - self.BASE_ADDRESS_EXTERNAL + byte)
+                val = await self.read_external(address - self.BASE_ADDRESS_EXTERNAL + byte)
                 result.append(val)
         elif(address >= self.BASE_ADDRESS_BLOCK and address < self.HIGH_ADDRESS_BLOCK):
             for byte in range(size):
-                val = yield self.fast_block_read()
+                val = await self.fast_block_read()
                 result.append(val)
         else:
             self.entity._log.warning("This address space does not exist!")
 
         return result
 
-    @cocotb.coroutine
-    def write(self, address, data):
+    async def write(self, address, data):
         if(address >= self.BASE_ADDRESS_I2C and address < self.HIGH_ADDRESS_I2C):
             self.entity._log.warning("I2C address space supported in simulation!")
         elif(address >= self.BASE_ADDRESS_EXTERNAL and address < self.HIGH_ADDRESS_EXTERNAL):
             for index, byte in enumerate(data):
-                yield self.write_external(address - self.BASE_ADDRESS_EXTERNAL + index, byte)
+                await self.write_external(address - self.BASE_ADDRESS_EXTERNAL + index, byte)
         elif(address >= self.BASE_ADDRESS_BLOCK and address < self.HIGH_ADDRESS_BLOCK):
             raise NotImplementedError("Unsupported request")
             # self._sidev.FastBlockWrite(data)
         else:
             self.entity._log.warning("This address space does not exist!")
 
-    @cocotb.coroutine
-    def read_external(self, address):
+    async def read_external(self, address):
         """Copied from silusb.sv testbench interface"""
         self.bus.RD_B <= 1
         self.bus.ADD <= self._x
-        self.bus.BUS_DATA <= self._high_impedence
+        self.bus.BUS_DATA <= self._high_impedance
         for _ in range(5):
-            yield RisingEdge(self.clock)
+            await RisingEdge(self.clock)
 
-        yield RisingEdge(self.clock)
+        await RisingEdge(self.clock)
         self.bus.ADD <= address + 0x4000
 
-        yield RisingEdge(self.clock)
+        await RisingEdge(self.clock)
         self.bus.RD_B <= 0
-        yield RisingEdge(self.clock)
+        await RisingEdge(self.clock)
         self.bus.RD_B <= 0
-        yield ReadOnly()
+        await ReadOnly()
         result = self.bus.BUS_DATA.value.integer
-        yield RisingEdge(self.clock)
+        await RisingEdge(self.clock)
         self.bus.RD_B <= 1
 
-        yield RisingEdge(self.clock)
+        await RisingEdge(self.clock)
         self.bus.RD_B <= 1
         self.bus.ADD <= self._x
 
-        yield RisingEdge(self.clock)
+        await RisingEdge(self.clock)
 
         for _ in range(5):
-            yield RisingEdge(self.clock)
+            await RisingEdge(self.clock)
 
-        raise ReturnValue(result)
+        return result
 
-    @cocotb.coroutine
-    def write_external(self, address, value):
+    async def write_external(self, address, value):
         """Copied from silusb.sv testbench interface"""
         self.bus.WR_B <= 1
         self.bus.ADD <= self._x
 
         for _ in range(5):
-            yield RisingEdge(self.clock)
+            await RisingEdge(self.clock)
 
-        yield RisingEdge(self.clock)
+        await RisingEdge(self.clock)
         self.bus.ADD <= address + 0x4000
         self.bus.BUS_DATA <= int(value)
-        yield Timer(1)  # This is hack for iverilog
+        await Timer(1)  # This is hack for iverilog
         self.bus.ADD <= address + 0x4000
         self.bus.BUS_DATA <= int(value)
-        yield RisingEdge(self.clock)
+        await RisingEdge(self.clock)
         self.bus.WR_B <= 0
-        yield Timer(1)  # This is hack for iverilog
+        await Timer(1)  # This is hack for iverilog
         self.bus.BUS_DATA <= int(value)
         self.bus.WR_B <= 0
-        yield RisingEdge(self.clock)
+        await RisingEdge(self.clock)
         self.bus.WR_B <= 0
-        yield Timer(1)  # This is hack for iverilog
+        await Timer(1)  # This is hack for iverilog
         self.bus.BUS_DATA <= int(value)
         self.bus.WR_B <= 0
-        yield RisingEdge(self.clock)
+        await RisingEdge(self.clock)
         self.bus.WR_B <= 1
-        self.bus.BUS_DATA <= self._high_impedence
-        yield Timer(1)  # This is hack for iverilog
+        self.bus.BUS_DATA <= self._high_impedance
+        await Timer(1)  # This is hack for iverilog
         self.bus.WR_B <= 1
-        self.bus.BUS_DATA <= self._high_impedence
-        yield RisingEdge(self.clock)
+        self.bus.BUS_DATA <= self._high_impedance
+        await RisingEdge(self.clock)
         self.bus.WR_B <= 1
         self.bus.ADD <= self._x
 
         for _ in range(5):
-            yield RisingEdge(self.clock)
+            await RisingEdge(self.clock)
 
-    @cocotb.coroutine
-    def fast_block_read(self):
-        yield RisingEdge(self.clock)
+    async def fast_block_read(self):
+        await RisingEdge(self.clock)
         self.bus.FREAD <= 1
         self.bus.FSTROBE <= 1
-        yield ReadOnly()
+        await ReadOnly()
         result = self.bus.FD.value.integer
-        yield RisingEdge(self.clock)
+        await RisingEdge(self.clock)
         self.bus.FREAD <= 0
         self.bus.FSTROBE <= 0
-        yield RisingEdge(self.clock)
-        raise ReturnValue(result)
+        await RisingEdge(self.clock)
+        return result

--- a/tests/test_SimGpio.py
+++ b/tests/test_SimGpio.py
@@ -55,8 +55,13 @@ registers:
 
 
 class TestSimGpio(unittest.TestCase):
+    def __init__(self, testname, tb='test_SimGpio.v', bus='basil.utils.sim.BasilBusDriver'):
+        super(TestSimGpio, self).__init__(testname)
+        self._test_tb = tb
+        self._sim_bus = bus
+
     def setUp(self):
-        cocotb_compile_and_run([os.path.join(os.path.dirname(__file__), 'test_SimGpio.v')])
+        cocotb_compile_and_run(sim_files=[os.path.join(os.path.dirname(__file__), self._test_tb)], sim_bus=self._sim_bus)
 
         self.chip = Dut(cnfg_yaml)
         self.chip.init()

--- a/tests/test_SimGpio_sbus.py
+++ b/tests/test_SimGpio_sbus.py
@@ -1,0 +1,27 @@
+#
+# ------------------------------------------------------------
+# Copyright (c) All rights reserved
+# SiLab, Institute of Physics, University of Bonn
+# ------------------------------------------------------------
+#
+
+import unittest
+import sys
+
+from tests.test_SimGpio import TestSimGpio
+
+
+if __name__ == '__main__':
+    # https://stackoverflow.com/a/2081750
+    test_loader = unittest.TestLoader()
+    test_names = test_loader.getTestCaseNames(TestSimGpio)
+
+    suite = unittest.TestSuite()
+
+    for test_name in test_names:
+        suite.addTest(TestSimGpio(test_name, 'test_SimGpio_sbus.v', 'basil.utils.sim.BasilSbusDriver'))
+    for test_name in test_names:
+        suite.addTest(TestSimGpio(test_name, 'test_SimGpio_sbus_top.v', 'basil.utils.sim.BasilSbusDriver'))
+
+    result = unittest.TextTestRunner().run(suite)
+    sys.exit(not result.wasSuccessful())

--- a/tests/test_SimGpio_sbus.v
+++ b/tests/test_SimGpio_sbus.v
@@ -1,0 +1,84 @@
+/**
+ * ------------------------------------------------------------
+ * Copyright (c) All rights reserved
+ * SiLab, Institute of Physics, University of Bonn
+ * ------------------------------------------------------------
+ */
+
+`timescale 1ps / 1ps
+
+`include "utils/sbus_to_ip.v"
+`include "gpio/gpio_core.v"
+`include "gpio/gpio_sbus.v"
+
+module tb (
+    input wire          BUS_CLK,
+    input wire          BUS_RST,
+    input wire  [15:0]  BUS_ADD,
+    input wire  [7:0]   BUS_DATA_IN,
+    output wire [7:0]   BUS_DATA_OUT,
+    input wire          BUS_RD,
+    input wire          BUS_WR
+);
+
+localparam GPIO_BASEADDR = 16'h0000;
+localparam GPIO_HIGHADDR = 16'h000f;
+
+localparam GPIO2_BASEADDR = 16'h0010;
+localparam GPIO2_HIGHADDR = 16'h001f;
+
+wire [7:0] BUS_DATA_OUT_1;
+wire [7:0] BUS_DATA_OUT_2;
+
+assign BUS_DATA_OUT = BUS_DATA_OUT_1 | BUS_DATA_OUT_2;
+
+// FIXME: hack for Verilator optimization error
+/* verilator lint_off UNOPT */
+wire [23:0] IO;
+
+assign IO[15:8] = IO[7:0];
+assign IO[23:20] = IO[19:16];
+/* verilator lint_on UNOPT */
+
+gpio_sbus #(
+    .BASEADDR(GPIO_BASEADDR),
+    .HIGHADDR(GPIO_HIGHADDR),
+    .IO_WIDTH(24),
+    .IO_DIRECTION(24'h0000ff),
+    .IO_TRI(24'hff0000)
+) i_gpio (
+    .BUS_CLK(BUS_CLK),
+    .BUS_RST(BUS_RST),
+    .BUS_ADD(BUS_ADD),
+    .BUS_DATA_IN(BUS_DATA_IN),
+    .BUS_DATA_OUT(BUS_DATA_OUT_1),
+    .BUS_RD(BUS_RD),
+    .BUS_WR(BUS_WR),
+    .IO(IO)
+);
+
+wire [15:0] IO_2;
+assign IO_2 = 16'ha5cd;
+
+gpio_sbus #(
+    .BASEADDR(GPIO2_BASEADDR),
+    .HIGHADDR(GPIO2_HIGHADDR),
+    .IO_WIDTH(16),
+    .IO_DIRECTION(16'h0000)
+) i_gpio2 (
+    .BUS_CLK(BUS_CLK),
+    .BUS_RST(BUS_RST),
+    .BUS_ADD(BUS_ADD),
+    .BUS_DATA_IN(BUS_DATA_IN),
+    .BUS_DATA_OUT(BUS_DATA_OUT_2),
+    .BUS_RD(BUS_RD),
+    .BUS_WR(BUS_WR),
+    .IO(IO_2)
+);
+
+initial begin
+    $dumpfile("gpio_sbus1.vcd");
+    $dumpvars(0);
+end
+
+endmodule

--- a/tests/test_SimGpio_sbus_top.v
+++ b/tests/test_SimGpio_sbus_top.v
@@ -1,0 +1,82 @@
+/**
+ * ------------------------------------------------------------
+ * Copyright (c) All rights reserved
+ * SiLab, Institute of Physics, University of Bonn
+ * ------------------------------------------------------------
+ */
+
+`timescale 1ps / 1ps
+
+`include "utils/bus_to_ip.v"
+`include "gpio/gpio_core.v"
+`include "gpio/gpio.v"
+
+module tb (
+    input wire          BUS_CLK,
+    input wire          BUS_RST,
+    input wire  [15:0]  BUS_ADD,
+    input wire  [7:0]   BUS_DATA_IN,
+    output wire [7:0]   BUS_DATA_OUT,
+    input wire          BUS_RD,
+    input wire          BUS_WR
+);
+
+localparam GPIO_BASEADDR = 16'h0000;
+localparam GPIO_HIGHADDR = 16'h000f;
+
+localparam GPIO2_BASEADDR = 16'h0010;
+localparam GPIO2_HIGHADDR = 16'h001f;
+
+// Connect tb internal bus to external split bus
+wire [7:0] BUS_DATA;
+assign BUS_DATA = BUS_DATA_IN;
+assign BUS_DATA_OUT = BUS_DATA;
+
+// FIXME: hack for Verilator optimization error
+/* verilator lint_off UNOPT */
+wire [23:0] IO;
+
+assign IO[15:8] = IO[7:0];
+assign IO[23:20] = IO[19:16];
+/* verilator lint_on UNOPT */
+
+gpio #(
+    .BASEADDR(GPIO_BASEADDR),
+    .HIGHADDR(GPIO_HIGHADDR),
+    .IO_WIDTH(24),
+    .IO_DIRECTION(24'h0000ff),
+    .IO_TRI(24'hff0000)
+) i_gpio (
+    .BUS_CLK(BUS_CLK),
+    .BUS_RST(BUS_RST),
+    .BUS_ADD(BUS_ADD),
+    .BUS_DATA(BUS_DATA),
+    .BUS_RD(BUS_RD),
+    .BUS_WR(BUS_WR),
+    .IO(IO)
+);
+
+wire [15:0] IO_2;
+assign IO_2 = 16'ha5cd;
+
+gpio #(
+    .BASEADDR(GPIO2_BASEADDR),
+    .HIGHADDR(GPIO2_HIGHADDR),
+    .IO_WIDTH(16),
+    .IO_DIRECTION(16'h0000)
+) i_gpio2 (
+    .BUS_CLK(BUS_CLK),
+    .BUS_RST(BUS_RST),
+    .BUS_ADD(BUS_ADD),
+    .BUS_DATA(BUS_DATA),
+    .BUS_RD(BUS_RD),
+    .BUS_WR(BUS_WR),
+    .IO(IO_2)
+);
+
+initial begin
+    $dumpfile("gpio_sbus2.vcd");
+    $dumpvars(0);
+end
+
+endmodule


### PR DESCRIPTION
Continue #145 
Extend `sbus` support & add modifications to run simulation with Verilator.
The bus can be either fully split (use/add new modules using `sbus`)
or it can be also only split in the tb module (same old modules, no other changes required).

- Adds simulation driver for split Basil bus.
- Adds split bus tests for GPIO modules (for new "sbus GPIO module" and old "normal bus GPIO module").

To run with Verilator (and get .vcd output) one may currently add
`mkfile += "EXTRA_ARGS += -Wno-UNSIGNED -Wno-WIDTH -Wno-WIDTHCONCAT --trace"`
to the Makefile