### PR TITLE
Fix bug and compability issues of SHT85 driver

### DIFF
--- a/basil/HL/sensirion_sht85.py
+++ b/basil/HL/sensirion_sht85.py
@@ -162,11 +162,12 @@ class sensirionSHT85(SensirionBridgeI2CDevice):
         return 100 * (float(data[1]) / (2**16 - 1))
 
     def to_dew_point(self, T, RH):
-        if T < 0:
-            T_n = 243.12
-            m = 17.6
-        else:
-            T_n = 272.62
-            m = 22.46
-        a = np.log(RH / 100.0) + m * T / (T_n + T)
-        return T_n * a / (m - a)
+        ''' returns the dew point using an approximation
+            approximation specified by Sensirion:
+            http://irtfweb.ifa.hawaii.edu/~tcs3/tcs3/Misc/Dewpoint_Calculation_Humidity_Sensor_E.pdf
+        '''
+        if RH == 0:
+            RH = self._to_humidity((0, 1))  # lowest non-zero rel. humidity
+        H = (np.log10(RH) - 2) / 0.4343 + (17.62 * T) / (243.12 + T)
+        Dp = 243.12 * H / (17.62 - H)
+        return Dp

--- a/basil/HL/sensirion_sht85.py
+++ b/basil/HL/sensirion_sht85.py
@@ -11,13 +11,14 @@ import struct
 from basil.HL.SensirionBridgeDevice import SensirionBridgeI2CDevice
 
 logger = logging.getLogger(__name__)
+logging.getLogger("sensirion_shdlc_driver.connection").setLevel(logging.ERROR)
 
 
 class sensirionSHT85(SensirionBridgeI2CDevice):
     '''
     Driver for the Sensirion SHT85 temperature and humidity sensor.
     Measurements can be performed in three repeatability modes:
-    low (0.15°C 0.21%RH) (default), medium (0.08°C 0.15%RH), high (0.04°C 0.08%RH)
+    low (0.15C 0.21%RH) (default), medium (0.08C 0.15%RH), high (0.04C 0.08%RH)
     with respective drawbacks in readout speed and power cosumption.
     The dew point can be estimated using humidity and temperature.
     Readout may also be performed asynchronously:

--- a/basil/HL/sensirion_sht85.py
+++ b/basil/HL/sensirion_sht85.py
@@ -18,7 +18,7 @@ class sensirionSHT85(SensirionBridgeI2CDevice):
     '''
     Driver for the Sensirion SHT85 temperature and humidity sensor.
     Measurements can be performed in three repeatability modes:
-    low (0.15C 0.21%RH) (default), medium (0.08C 0.15%RH), high (0.04C 0.08%RH)
+    low (0.15°C 0.21%RH) (default), medium (0.08°C 0.15%RH), high (0.04°C 0.08%RH)
     with respective drawbacks in readout speed and power cosumption.
     The dew point can be estimated using humidity and temperature.
     Readout may also be performed asynchronously:


### PR DESCRIPTION
A bug caused, that, with each call of get_temperaruture(), three measurements where performed by the sensor, while only the result with the chosen repeatablilaty was returned and the other two results where discarded. Also the decoding of the response was not compatible with python 2.