### PR TITLE
Improve Verilator compatibility 2

### DIFF
--- a/basil/firmware/modules/utils/generic_fifo.v
+++ b/basil/firmware/modules/utils/generic_fifo.v
@@ -74,7 +74,9 @@ always @(posedge clk) begin
 end
 
 always @(posedge clk)
-    if(read && !empty)
+    if (reset)
+        empty <= 1;
+    else if(read && !empty)
         if(rd_pointer == DEPTH-1'b1)
             empty <= (wr_pointer == 0);
         else


### PR DESCRIPTION
In tests, e.g. https://github.com/SiLab-Bonn/basil/blob/master/tests/test_SimFifo8to32.py,
`empty` may not settle correctly with Verilator, so that tests will fail.
This is solved by adding reset for `empty`.