### PR TITLE
Better enable Verilator's delayed assignment warning

### DIFF
--- a/basil/utils/sim/utils.py
+++ b/basil/utils/sim/utils.py
@@ -46,7 +46,7 @@ def cocotb_makefile(sim_files, top_level='tb', test_module='basil.utils.sim.Test
     try:
         if os.environ['SIM'] == 'verilator':
             mkfile += "EXTRA_ARGS += -DVERILATOR_SIM\n"
-            mkfile += "EXTRA_ARGS += -Wno-WIDTH -Wno-TIMESCALEMOD\n"
+            mkfile += "EXTRA_ARGS += -Wno-WIDTH -Wno-TIMESCALEMOD -Wwarn-ASSIGNDLY\n"
     except KeyError:
         pass
 


### PR DESCRIPTION
...to avoid timescale issues / detect hidden pitfalls like `assign #1 a = b;`