### PR TITLE
Support for cocotb-bus 0.2.0

### DIFF
--- a/basil/utils/sim/BasilSbusDriver.py
+++ b/basil/utils/sim/BasilSbusDriver.py
@@ -34,16 +34,16 @@ class BasilSbusDriver(BusDriver):
 
     async def init(self):
         # Defaults
-        self.bus.BUS_RST <= 1
-        self.bus.BUS_RD <= 0
-        self.bus.BUS_WR <= 0
-        self.bus.BUS_ADD <= self._x
-        self.bus.BUS_DATA_IN <= self._high_impedance
+        self.bus.BUS_RST.value = 1
+        self.bus.BUS_RD.value = 0
+        self.bus.BUS_WR.value = 0
+        self.bus.BUS_ADD.value = self._x
+        self.bus.BUS_DATA_IN.value = self._high_impedance
 
         for _ in range(8):
             await RisingEdge(self.clock)
 
-        self.bus.BUS_RST <= 0
+        self.bus.BUS_RST.value = 0
 
         for _ in range(2):
             await RisingEdge(self.clock)
@@ -64,8 +64,8 @@ class BasilSbusDriver(BusDriver):
         if size == 0:
             return result
 
-        self.bus.BUS_RD <= 1
-        self.bus.BUS_ADD <= address
+        self.bus.BUS_RD.value = 1
+        self.bus.BUS_ADD.value = address
 
         byte = 0
 
@@ -78,9 +78,9 @@ class BasilSbusDriver(BusDriver):
             else:
                 byte += 1
 
-            self.bus.BUS_ADD <= address + byte
+            self.bus.BUS_ADD.value = address + byte
             if byte >= size:
-                self.bus.BUS_RD <= 0
+                self.bus.BUS_RD.value = 0
 
             await ReadOnly()
 
@@ -98,8 +98,8 @@ class BasilSbusDriver(BusDriver):
 
         await RisingEdge(self.clock)
 
-        self.bus.BUS_ADD <= self._x
-        self.bus.BUS_RD <= 0
+        self.bus.BUS_ADD.value = self._x
+        self.bus.BUS_RD.value = 0
 
         return result
 
@@ -108,15 +108,15 @@ class BasilSbusDriver(BusDriver):
         await RisingEdge(self.clock)
 
         for index, byte in enumerate(data):
-            self.bus.BUS_DATA_IN <= byte
-            self.bus.BUS_WR <= 1
-            self.bus.BUS_ADD <= address + index
+            self.bus.BUS_DATA_IN.value = byte
+            self.bus.BUS_WR.value = 1
+            self.bus.BUS_ADD.value = address + index
 
             await RisingEdge(self.clock)
 
         if self._has_byte_acces and self.bus.BUS_BYTE_ACCESS.value.integer == 0:
             raise NotImplementedError("BUS_BYTE_ACCESS for write to be implemented.")
 
-        self.bus.BUS_ADD <= self._x
-        self.bus.BUS_DATA_IN <= self._high_impedance
-        self.bus.BUS_WR <= 0
+        self.bus.BUS_ADD.value = self._x
+        self.bus.BUS_DATA_IN.value = self._high_impedance
+        self.bus.BUS_WR.value = 0

--- a/basil/utils/sim/BasilSbusDriver.py
+++ b/basil/utils/sim/BasilSbusDriver.py
@@ -20,7 +20,7 @@ class BasilSbusDriver(BusDriver):
     _optional_signals = ["BUS_BYTE_ACCESS"]
 
     def __init__(self, entity):
-        BusDriver.__init__(self, entity, "", entity.BUS_CLK)
+        BusDriver.__init__(self, entity, "", entity.BUS_CLK, case_insensitive=False)
 
         # Create an appropriately sized high-impedance value
         self._high_impedance = BinaryValue(n_bits=len(self.bus.BUS_DATA_IN))

--- a/basil/utils/sim/SiLibUsbBusDriver.py
+++ b/basil/utils/sim/SiLibUsbBusDriver.py
@@ -44,14 +44,14 @@ class SiLibUsbBusDriver(BusDriver):
     async def init(self):
         # Defaults
         # self.bus.BUS_RST<= 1
-        self.bus.RD_B <= 1
-        self.bus.WR_B <= 1
-        self.bus.ADD <= 0
-        self.bus.FREAD <= 0
-        self.bus.FSTROBE <= 0
-        self.bus.FMODE <= 0
-        self.bus.BUS_DATA <= self._high_impedance
-        self.bus.FD <= self._high_impedance
+        self.bus.RD_B.value = 1
+        self.bus.WR_B.value = 1
+        self.bus.ADD.value = 0
+        self.bus.FREAD.value = 0
+        self.bus.FSTROBE.value = 0
+        self.bus.FMODE.value = 0
+        self.bus.BUS_DATA.value = self._high_impedance
+        self.bus.FD.value = self._high_impedance
 
         # wait for reset
         for _ in range(200):
@@ -90,27 +90,27 @@ class SiLibUsbBusDriver(BusDriver):
 
     async def read_external(self, address):
         """Copied from silusb.sv testbench interface"""
-        self.bus.RD_B <= 1
-        self.bus.ADD <= self._x
-        self.bus.BUS_DATA <= self._high_impedance
+        self.bus.RD_B.value = 1
+        self.bus.ADD.value = self._x
+        self.bus.BUS_DATA.value = self._high_impedance
         for _ in range(5):
             await RisingEdge(self.clock)
 
         await RisingEdge(self.clock)
-        self.bus.ADD <= address + 0x4000
+        self.bus.ADD.value = address + 0x4000
 
         await RisingEdge(self.clock)
-        self.bus.RD_B <= 0
+        self.bus.RD_B.value = 0
         await RisingEdge(self.clock)
-        self.bus.RD_B <= 0
+        self.bus.RD_B.value = 0
         await ReadOnly()
         result = self.bus.BUS_DATA.value.integer
         await RisingEdge(self.clock)
-        self.bus.RD_B <= 1
+        self.bus.RD_B.value = 1
 
         await RisingEdge(self.clock)
-        self.bus.RD_B <= 1
-        self.bus.ADD <= self._x
+        self.bus.RD_B.value = 1
+        self.bus.ADD.value = self._x
 
         await RisingEdge(self.clock)
 
@@ -121,49 +121,49 @@ class SiLibUsbBusDriver(BusDriver):
 
     async def write_external(self, address, value):
         """Copied from silusb.sv testbench interface"""
-        self.bus.WR_B <= 1
-        self.bus.ADD <= self._x
+        self.bus.WR_B.value = 1
+        self.bus.ADD.value = self._x
 
         for _ in range(5):
             await RisingEdge(self.clock)
 
         await RisingEdge(self.clock)
-        self.bus.ADD <= address + 0x4000
-        self.bus.BUS_DATA <= int(value)
+        self.bus.ADD.value = address + 0x4000
+        self.bus.BUS_DATA.value = int(value)
         await Timer(1)  # This is hack for iverilog
-        self.bus.ADD <= address + 0x4000
-        self.bus.BUS_DATA <= int(value)
+        self.bus.ADD.value = address + 0x4000
+        self.bus.BUS_DATA.value = int(value)
         await RisingEdge(self.clock)
-        self.bus.WR_B <= 0
+        self.bus.WR_B.value = 0
         await Timer(1)  # This is hack for iverilog
-        self.bus.BUS_DATA <= int(value)
-        self.bus.WR_B <= 0
+        self.bus.BUS_DATA.value = int(value)
+        self.bus.WR_B.value = 0
         await RisingEdge(self.clock)
-        self.bus.WR_B <= 0
+        self.bus.WR_B.value = 0
         await Timer(1)  # This is hack for iverilog
-        self.bus.BUS_DATA <= int(value)
-        self.bus.WR_B <= 0
+        self.bus.BUS_DATA.value = int(value)
+        self.bus.WR_B.value = 0
         await RisingEdge(self.clock)
-        self.bus.WR_B <= 1
-        self.bus.BUS_DATA <= self._high_impedance
+        self.bus.WR_B.value = 1
+        self.bus.BUS_DATA.value = self._high_impedance
         await Timer(1)  # This is hack for iverilog
-        self.bus.WR_B <= 1
-        self.bus.BUS_DATA <= self._high_impedance
+        self.bus.WR_B.value = 1
+        self.bus.BUS_DATA.value = self._high_impedance
         await RisingEdge(self.clock)
-        self.bus.WR_B <= 1
-        self.bus.ADD <= self._x
+        self.bus.WR_B.value = 1
+        self.bus.ADD.value = self._x
 
         for _ in range(5):
             await RisingEdge(self.clock)
 
     async def fast_block_read(self):
         await RisingEdge(self.clock)
-        self.bus.FREAD <= 1
-        self.bus.FSTROBE <= 1
+        self.bus.FREAD.value = 1
+        self.bus.FSTROBE.value = 1
         await ReadOnly()
         result = self.bus.FD.value.integer
         await RisingEdge(self.clock)
-        self.bus.FREAD <= 0
-        self.bus.FSTROBE <= 0
+        self.bus.FREAD.value = 0
+        self.bus.FSTROBE.value = 0
         await RisingEdge(self.clock)
         return result


### PR DESCRIPTION
This fix adds compatibility with the latest version of cocotb-bus which is installed when installing cocotb. They introduced case-insensitive signal names on a bus in 0.2.0 which tries to match lowercase names by default.
At the same time it adopts the new assignment sytax, replacing `<=`.