### PR TITLE
Allow optional, device-specific formatting of SCPI query return strings

### DIFF
--- a/basil/HL/keithley_2410.yaml
+++ b/basil/HL/keithley_2410.yaml
@@ -26,3 +26,9 @@ set_current_sense_range: SENS:CURR:RANGE
 get_current_sense_range: SENS:CURR:RANGE?
 get_reading: READ?
 set_current_nlpc: SENS:CURR:NPLC
+# Special keyword for formatting query results to allow direct conversions to numeric types (e.g. float(get_current()))
+__scpi_query_fmt:
+  fmt_sep: ','
+  fmt_method:
+    get_voltage: '{0}'
+    get_current: '{1}'

--- a/basil/HL/scpi.py
+++ b/basil/HL/scpi.py
@@ -67,7 +67,7 @@ class scpi(HardwareLayer):
         if '__scpi_query_fmt' in self._scpi_commands:
             self._scpi_query_fmt = self._scpi_commands.pop('__scpi_query_fmt')
         # Check if we want to enable formatting from the init
-        if 'device_formatting' in self._init and self._init['device_formatting']:
+        if 'enable_formatting' in self._init and self._init['enable_formatting']:
             self.enable_formatting()
 
     def __getattr__(self, name):

--- a/basil/HL/scpi.py
+++ b/basil/HL/scpi.py
@@ -47,7 +47,7 @@ class scpi(HardwareLayer):
                 raise RuntimeError('Wrong device description (' + self._init['device'] + ') loaded for ' + name)
         # Device specific query return value formatting
         if '__scpi_query_fmt' in self._scpi_commands:
-            self._scpi_query_fmt = self._scpi_commands['_scpi_query_fmt']
+            self._scpi_query_fmt = self._scpi_commands.pop('_scpi_query_fmt')
 
     def __getattr__(self, name):
         '''dynamically adding device specific commands

--- a/basil/HL/scpi.py
+++ b/basil/HL/scpi.py
@@ -34,6 +34,15 @@ class scpi(HardwareLayer):
     def has_formatting(self, val):
         raise AttributeError("Attribute is read-only")
 
+    @property
+    def formatting_enabled(self):
+        '''Whether or not device has SCPI query formatting is enabled'''
+        return self._formatting_enabled
+
+    @formatting_enabled.setter
+    def formatting_enabled(self, val):
+        raise AttributeError("Attribute is read-only")
+
     def __init__(self, intf, conf):
         super(scpi, self).__init__(intf, conf)
 
@@ -57,6 +66,9 @@ class scpi(HardwareLayer):
         # Device specific query return value formatting
         if '__scpi_query_fmt' in self._scpi_commands:
             self._scpi_query_fmt = self._scpi_commands.pop('__scpi_query_fmt')
+        # Check if we want to enable formatting from the init
+        if 'device_formatting' in self._init and self._init['device_formatting']:
+            self.enable_formatting()
 
     def __getattr__(self, name):
         '''dynamically adding device specific commands

--- a/basil/HL/scpi.py
+++ b/basil/HL/scpi.py
@@ -47,7 +47,7 @@ class scpi(HardwareLayer):
                 raise RuntimeError('Wrong device description (' + self._init['device'] + ') loaded for ' + name)
         # Device specific query return value formatting
         if '__scpi_query_fmt' in self._scpi_commands:
-            self._scpi_query_fmt = self._scpi_commands.pop('_scpi_query_fmt')
+            self._scpi_query_fmt = self._scpi_commands.pop('__scpi_query_fmt')
 
     def __getattr__(self, name):
         '''dynamically adding device specific commands
@@ -65,7 +65,7 @@ class scpi(HardwareLayer):
             elif len(name_split) == 2 and name_split[0] == 'get' and not args and not kwargs:
                 res = self._intf.query(command)
                 if self._scpi_query_fmt and name in self._scpi_query_fmt['fmt_method']:
-                    res = self._scpi_query_fmt['fmt_method'][name].format(res.strip().split(self._scpi_query_fmt['fmt_sep']))
+                    res = self._scpi_query_fmt['fmt_method'][name].format(*res.strip().split(self._scpi_query_fmt['fmt_sep']))
                 return res
             elif len(name_split) >= 1 and not args and not kwargs:
                 self._intf.write(command)

--- a/tests/formatting.yaml
+++ b/tests/formatting.yaml
@@ -1,0 +1,38 @@
+spec: "1.1"
+devices:
+  device 1:
+    eom:
+      ASRL INSTR:
+        q: "\r\n"
+        r: "\n"
+      USB INSTR:
+        q: "\n"
+        r: "\n"
+      TCPIP INSTR:
+        q: "\n"
+        r: "\n"
+      GPIB INSTR:
+        q: "\n"
+        r: "\n"
+    dialogues:
+      - q: "*IDN?"
+        r: "KEITHLEY INSTRUMENTS INC.,MODEL 2410"
+    properties:
+      selected_channel:
+        default: 'VOLT'
+        setter:
+          q: "SENSE:FUNC '{}'"
+    channels:
+      type1:
+        ids: ['VOLT']
+        can_select: False
+        properties:
+          value:
+            default: 1.0
+            getter:
+              q: ':READ?'
+              r: '-5.124E-05,+1.789E-10,+1.001E37,1.001E5'
+
+resources:
+  ASRL1::INSTR:
+    device: device 1

--- a/tests/test_SimSCPIFormatting.py
+++ b/tests/test_SimSCPIFormatting.py
@@ -25,7 +25,7 @@ hw_drivers:
 '''
 
 
-class TestSimScpiFormatting(unittest.TestCase):
+class TestSimScpi(unittest.TestCase):
 
     def setUp(self):
         self.cfg = yaml.safe_load(cnfg_yaml)

--- a/tests/test_SimSCPIFormatting.py
+++ b/tests/test_SimSCPIFormatting.py
@@ -47,7 +47,7 @@ class TestSimScpi(unittest.TestCase):
         # Disable formatting
         self.device['Sourcemeter'].disable_formatting()
         self.assertEqual(voltage, '-5.124E-05')
-    
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/test_SimSCPIFormatting.py
+++ b/tests/test_SimSCPIFormatting.py
@@ -21,32 +21,43 @@ hw_drivers:
     interface : Visa
     init      :
         device : Keithley 2410
+        device_formatting: true
 '''
 
 
-class TestSimScpi(unittest.TestCase):
+class TestSimScpiFormatting(unittest.TestCase):
 
     def setUp(self):
         self.cfg = yaml.safe_load(cnfg_yaml)
         self.device = Dut(self.cfg)
         self.device.init()
+        # Check that formatting is present
+        self.assertTrue(self.device['Sourcemeter'].has_formatting)
+        # Check that formatting is enabled after init
+        self.assertTrue(self.device['Sourcemeter'].formatting_enabled)
 
     def tearDown(self):
         self.device.close()
 
     def test_read_voltage(self):
-        voltage = self.device['Sourcemeter'].get_voltage().split(',')[0]
+        voltage = self.device['Sourcemeter'].get_voltage()
         self.assertEqual(voltage, '-5.124E-05')
 
-    def test_read_voltage_formatted(self):
-        # Check that formatting is present
-        self.assertTrue(self.device['Sourcemeter'].has_formatting)
-        # Enable formatting
-        self.device['Sourcemeter'].enable_formatting()
-        voltage = self.device['Sourcemeter'].get_voltage()
+    def test_read_current(self):
+        voltage = self.device['Sourcemeter'].get_current()
+        self.assertEqual(voltage, '+1.789E-10')
+
+    def test_read_voltage_unformatted(self):
+        # Check that formatting is enabled
+        self.assertTrue(self.device['Sourcemeter'].formatting_enabled)
         # Disable formatting
         self.device['Sourcemeter'].disable_formatting()
+        voltage = self.device['Sourcemeter'].get_voltage().split(',')[0]
         self.assertEqual(voltage, '-5.124E-05')
+        # Check that formatting is disabled
+        self.assertFalse(self.device['Sourcemeter'].formatting_enabled)
+        # Enable formatting
+        self.device['Sourcemeter'].enable_formatting()
 
 
 if __name__ == '__main__':

--- a/tests/test_SimSCPIFormatting.py
+++ b/tests/test_SimSCPIFormatting.py
@@ -43,10 +43,6 @@ class TestSimScpi(unittest.TestCase):
         voltage = self.device['Sourcemeter'].get_voltage()
         self.assertEqual(voltage, '-5.124E-05')
 
-    def test_read_current(self):
-        voltage = self.device['Sourcemeter'].get_current()
-        self.assertEqual(voltage, '+1.789E-10')
-
     def test_read_voltage_unformatted(self):
         # Check that formatting is enabled
         self.assertTrue(self.device['Sourcemeter'].formatting_enabled)

--- a/tests/test_SimSCPIFormatting.py
+++ b/tests/test_SimSCPIFormatting.py
@@ -21,7 +21,7 @@ hw_drivers:
     interface : Visa
     init      :
         device : Keithley 2410
-        device_formatting: true
+        enable_formatting: true
 '''
 
 

--- a/tests/test_SimSCPIFormatting.py
+++ b/tests/test_SimSCPIFormatting.py
@@ -23,6 +23,7 @@ hw_drivers:
         device : Keithley 2410
 '''
 
+
 class TestSimScpi(unittest.TestCase):
 
     def setUp(self):
@@ -36,7 +37,7 @@ class TestSimScpi(unittest.TestCase):
     def test_read_voltage(self):
         voltage = self.device['Sourcemeter'].get_voltage().split(',')[0]
         self.assertEqual(voltage, '-5.124E-05')
-    
+
     def test_read_voltage_formatted(self):
         # Check that formatting is present
         self.assertTrue(self.device['Sourcemeter'].has_formatting)

--- a/tests/test_SimSCPIFormatting.py
+++ b/tests/test_SimSCPIFormatting.py
@@ -1,0 +1,52 @@
+import unittest
+import yaml
+import os
+from basil.dut import Dut
+
+k2410def_yaml = os.path.join(os.path.dirname(__file__), "formatting.yaml")
+
+cnfg_yaml = f'''
+transfer_layer:
+  - name     : Visa
+    type     : Visa
+    init     :
+        resource_name : ASRL1::INSTR
+        read_termination : "\\n"
+        write_termination : "\\r\\n"
+        backend : "{k2410def_yaml}@sim"
+
+hw_drivers:
+  - name      : Sourcemeter
+    type      : scpi
+    interface : Visa
+    init      :
+        device : Keithley 2410
+'''
+
+class TestSimScpi(unittest.TestCase):
+
+    def setUp(self):
+        self.cfg = yaml.safe_load(cnfg_yaml)
+        self.device = Dut(self.cfg)
+        self.device.init()
+
+    def tearDown(self):
+        self.device.close()
+
+    def test_read_voltage(self):
+        voltage = self.device['Sourcemeter'].get_voltage().split(',')[0]
+        self.assertEqual(voltage, '-5.124E-05')
+    
+    def test_read_voltage_formatted(self):
+        # Check that formatting is present
+        self.assertTrue(self.device['Sourcemeter'].has_formatting)
+        # Enable formatting
+        self.device['Sourcemeter'].enable_formatting()
+        voltage = self.device['Sourcemeter'].get_voltage()
+        # Disable formatting
+        self.device['Sourcemeter'].disable_formatting()
+        self.assertEqual(voltage, '-5.124E-05')
+    
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
This PR addresses #166. It enables optional, device-specific formatting of SCPI query return strings for SCPI-type devices which are created from a device description yaml instead of having a dedicated hardware layer Python script. This is helpful if devices return *multiple* fields per query of which only one corresponds to the desired information.

## API
This PR adds the following API for classes inheriting from `basil.HL.scpi.scpi` base class, referred to as `scpi` in the following:

    scpi.has_formatting -> bool : Attribute, whether formatting exists for this SCPI-device
    scpi.formatting_enabled -> bool : Attribute, whether SCPI-query formatting is enabled for this instance
    scpi.enable_formatting() -> None : Method, enables formatting, raises AttributeError if no formatting exists
    scpi.disable_formatting() -> None: Method, disables formatting

## Specifying formatting
Add the following structure to the device descriptor yaml:

    __scpi_query_fmt:
      fmt_sep: ','  # The separator value for multi-value return strings
      fmt_method:  # Define the format string for each method; currently only indexing is supported
        get_voltage: '{0}'  # Voltage information is at index 0 of multi-value string for this device
        get_current: '{1}'  # Voltage information is at index 0 of multi-value string for this device
        ...  # Add more methods who return multi-value strings

Adding formatting is optional.

## Enabling/disabling formatting
Formatting can be enabled after initialization of the SCPI device by calling

    scpi.enable_formatting()
    scpi.disable_formatting()

To automatically enable formatting, pass `enable_formatting: true` to the `init`-field in the  device config yamls `hw_driver`:

    # Snippet
    hw_drivers:
      - name      : Sourcemeter
        type      : scpi
        interface : Visa
        init      :
            device : Keithley 2410
            enable_formatting: true

## Example
A Keithley 2410 SMU  is generated from [this](https://github.com/SiLab-Bonn/basil/blob/master/basil/HL/keithley_2410.yaml) device descriptor yaml which contains formatting. Reading a voltage from the SMU with basil (using [this](https://github.com/SiLab-Bonn/basil/blob/master/examples/lab_devices/keithley2410_pyvisa.yaml) `smu_config`) looks like this:

    # ... do the imports and define smu_config

    # Create device
    smu = Dut(smu_config)
    smu.init()
    
    # Read voltage
    smu['Sourcemeter'].get_voltage()
    
    # Prints something like '-5.124E-05,+1.789E-10,+1.001E37,1.001E5'

The desired information, the voltage, is found in the 0th field of the return string. Consequently, the following code is often found with basil

    voltage = float(smu['Sourcemeter'].get_voltage().split(',')[0])

This PR enables to define specific formatting per method in the [device descriptor yaml of the e.g. Keithley 2410](https://github.com/leloup314/basil/blob/master/basil/HL/keithley_2410.yaml#L30) so that the call changes to

    # Enable formatting
    smu['sourcemeter'].enable_formatting()

    # Read voltage
    voltage = smu['Sourcemeter'].get_voltage()  # Returns '-5.124E-05'

    # Convert to float
    voltage = float(voltage)

which corresponds to a more consistent behavior with respect to the method called.