### PR TITLE
Add HP 4284A LCR meter to basil

### DIFF
--- a/basil/HL/hp_4284a.yaml
+++ b/basil/HL/hp_4284a.yaml
@@ -1,0 +1,15 @@
+# Device description for the Hewlett Packard LCR meter. 
+# Only GPIB shows working communication with this device!
+identifier : HEWLETT-PACKARD,HP4284A
+open_correction: CORR:OPEN
+short_correction: CORR:SHOR
+trigger: TRIG
+set_trigger_mode: TRIG:SOUR
+get_trigger_mode: TRIG:SOUR?
+set_ac_voltage: VOLT
+get_ac_voltage: VOLT?
+set_frequency: FREQ
+get_frequency: FREQ?
+set_meas_quantity: FUNC:IMP
+get_meas_quantity: FUN:IMP?
+get_value: FETC?

--- a/basil/HL/hp_4284a.yaml
+++ b/basil/HL/hp_4284a.yaml
@@ -1,6 +1,5 @@
 # Device description for the Hewlett Packard LCR meter. 
 # Only GPIB shows working communication with this device!
-identifier : HEWLETT-PACKARD,HP4284A
 open_correction: CORR:OPEN
 short_correction: CORR:SHOR
 trigger: TRIG

--- a/examples/lab_devices/hp_4284a_pyvisa.yaml
+++ b/examples/lab_devices/hp_4284a_pyvisa.yaml
@@ -1,0 +1,12 @@
+transfer_layer:
+  - name  : Visa_lcr
+    type  : Visa
+    init  :
+        resource_name    : GPIB0::17::INSTR
+        
+hw_drivers:
+  - name      : LCRMeter
+    type      : scpi
+    interface : Visa_lcr
+    init      :
+         device    : HP 4284A


### PR DESCRIPTION
This PR add the Hewlett-Packard 44284A precision LCR meter to basil. Unfortunately, it currently only works relatively straight forward using GPIB driver under Windows. 