### PR TITLE
FIX: remove NTC temperature logging

### DIFF
--- a/basil/HL/NTCRegister.py
+++ b/basil/HL/NTCRegister.py
@@ -73,7 +73,6 @@ class NTCRegister(HardwareLayer):
             j = arg[0]
 
         k = 1.0 / (math.log(r_ratio / self.R_RATIO[j]) / self.B_CONST[j] + 1 / self.TEMP[j])[0]
-        logger.info("Temperature (C): %f", k - 273.15)
 
         if unit == "C":
             return k - 273.15


### PR DESCRIPTION
Remove unnecessary logging in `get_temerpature` function of NTCRegister due to spamming of consol. Logging should be done by user.

Closes #170 