### PR TITLE
Add option to pass build arguments to verilator

### DIFF
--- a/basil/utils/sim/utils.py
+++ b/basil/utils/sim/utils.py
@@ -15,7 +15,7 @@ def get_basil_dir():
 
 
 def cocotb_makefile(sim_files, top_level='tb', test_module='basil.utils.sim.Test', sim_host='localhost', sim_port=12345, sim_bus='basil.utils.sim.BasilBusDriver',
-                    end_on_disconnect=True, include_dirs=(), extra_defines=(), compile_args=(), extra=''):
+                    end_on_disconnect=True, include_dirs=(), extra_defines=(), compile_args=(), build_args=(), extra=''):
 
     basil_dir = get_basil_dir()
     include_dirs += (basil_dir + "/firmware/modules", basil_dir + "/firmware/modules/includes")
@@ -38,6 +38,7 @@ def cocotb_makefile(sim_files, top_level='tb', test_module='basil.utils.sim.Test
     mkfile += "NOT_ICARUS_INCLUDE_DIRS=+incdir+./ %s\n" % (" ".join('+incdir+' + str(e) for e in include_dirs))  # this is for modelsim better full path?
 
     mkfile += "COMPILE_ARGS_DEFINES = %s\n" % (" ".join(str(e) for e in compile_args))  # extra compiler args, e.g., for adding Xilinx's glbl.v to Icarus use "-s glbl"
+    mkfile += "BUILD_ARGS_DEFINES = %s\n" % (" ".join(str(e) for e in build_args))  # extra build args passed to build stage in supported simulators
 
     mkfile += "\n"
     mkfile += extra
@@ -74,6 +75,9 @@ else
 endif
 
 COMPILE_ARGS += $(COMPILE_ARGS_DEFINES)
+ifeq ($(SIM), verilator)
+    BUILD_ARGS += $(BUILD_ARGS_DEFINES)
+endif
 
 TOPLEVEL_LANG?=verilog
 export TOPLEVEL_LANG


### PR DESCRIPTION
cocotb supports `BUILD_ARGS` that can be passed to the build step when using verilator. This PR adds a kwarg to `basil/utils/sim/utils.py` to pass `BUILD_ARGS` from user to verilator via the produced Makefile.
For example, this is useful to speed up the compilation phase by adding multithreading to the `make` call.