### PR TITLE
FIX: X-ray Debyeflex 3003 driver

### DIFF
--- a/basil/HL/debyeflex3003.py
+++ b/basil/HL/debyeflex3003.py
@@ -80,10 +80,10 @@ class debyeflex3003(HardwareLayer):
             self.write("SV:{:02d}".format(vol))
             logger.info("Set tube voltage to {:.1f} kV".format(self.get_nominal_voltage()))
 
-    def set_highvoltage_on(self):
+    def set_high_voltage_on(self):
         self.write("HV:1")
 
-    def set_highvoltage_off(self):
+    def set_high_voltage_off(self):
         self.write("HV:0")
 
     def open_shutter(self, shutter=1):


### PR DESCRIPTION
This PR fixes the inconsistent function name in the X-ray machine driver, reported in #185.