### PR TITLE
Improve exception handling for dynamic method generation

### DIFF
--- a/tests/test_SimScpi.py
+++ b/tests/test_SimScpi.py
@@ -50,9 +50,9 @@ class TestSimScpi(unittest.TestCase):
         with self.assertRaises(ValueError):
             self.device['Pulser'].set_on(1, 2)
 
-    def test_exception(self):
-        with self.assertRaises(ValueError):
-            self.device['Pulser'].unknown_function()
+    def test_unknown_method(self):
+        with self.assertRaises(AttributeError):
+            self.device['Pulser'].unknown_method()
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
This PR adds more streamlined exception handling for the SCPI `HL`.

Currently, when the dynamically-generated method fails to create a SCPI command because of **any** exception, the bare exception is excepted and a `ValueError` is raised within the exception handling. Due to Pythons [exception chaning](https://docs.python.org/3.1/whatsnew/3.0.html#changes-to-exceptions), this produces a confusing traceback, not clearlyindictaing that _no such attribute is available_.

This PR changes this behavior by 

1. Catching and handling the possible exceptions occurring on SCPI command creation
2. Checking for successful SCPI command creation and  raising an `AttributeError` if no such SCPI method is available

This mirrors the expected behaviour of `arbitrary_object.non_existing_method()` generating an `AttributeError`
