### PR TITLE
serial and visa baud rate init parameter compatibility

### DIFF
--- a/.github/workflows/regression-tests.yml
+++ b/.github/workflows/regression-tests.yml
@@ -16,7 +16,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: [3.8]
+        python-version: [3.11]
     steps:
     - uses: actions/checkout@v2
     - name: Set up Python ${{matrix.python-version}}
@@ -31,7 +31,7 @@ jobs:
   tests:
 
     name: Python ${{matrix.python-version}} | ${{matrix.sim}} 
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     env:
       SIM: ${{matrix.sim}}
 
@@ -39,24 +39,24 @@ jobs:
       fail-fast: false
       matrix:
         include:
+          - sim: icarus
+            python-version: '3.11'
 
           - sim: icarus
-            python-version: 3.7
-
-          - sim: icarus
-            python-version: 3.8
+            python-version: '3.10'
 
           - sim: verilator
-            sim-version: v4.106
-            python-version: 3.8
+            sim-version: v5.020
+            python-version: '3.10'
             pytest-marker: "-m verilator"
 
     steps:
     - uses: actions/checkout@v1
-    - uses: conda-incubator/setup-miniconda@v2
+    - name: Set up Anaconda ${{matrix.python-version}}
+      uses: conda-incubator/setup-miniconda@v2
       with:
         auto-update-conda: true
-        python-version: ${{ matrix.python-version }}
+        python-version: ${{matrix.python-version}}
 
     - name: Install Conda dependencies
       shell: bash -l {0}
@@ -67,12 +67,12 @@ jobs:
     - name: Install Python dependencies
       shell: bash -l {0}
       run: |
-        pip install pyvisa pyvisa-sim pytest coveralls pytest-cov cocotb==1.5.2
+        pip install pyvisa pyvisa-sim pytest coveralls pytest-cov cocotb>=1.8.1 cocotb-bus
   
     - name: Install Verilator
       if: matrix.sim == 'verilator'
       run: |
-        sudo apt install -y --no-install-recommends make g++ perl python3 autoconf flex bison libfl2 libfl-dev zlibc zlib1g zlib1g-dev
+        sudo apt install -y --no-install-recommends make g++ help2man perl autoconf flex bison libfl2 libfl-dev zlib1g zlib1g-dev
         git clone https://github.com/verilator/verilator.git -b ${{matrix.sim-version}}
         cd verilator
         autoconf

--- a/basil/HL/JtagMaster.py
+++ b/basil/HL/JtagMaster.py
@@ -102,7 +102,7 @@ class JtagMaster(RegisterHardwareLayer):
         bit_number = self._test_input(data)
         self.SIZE = bit_number
 
-        if type(data[0]) == BitLogic:
+        if isinstance(data[0], BitLogic):
             data_byte = self._bitlogic2bytes(data)
         else:
             data_byte = self._raw_data2bytes(data)
@@ -135,7 +135,7 @@ class JtagMaster(RegisterHardwareLayer):
             self.WORD_COUNT = bit_number // word_size
             self.SIZE = word_size
 
-        if type(data[0]) == BitLogic:
+        if isinstance(data[0], BitLogic):
             data_byte = self._bitlogic2bytes(data)
         else:
             data_byte = self._raw_data2bytes(data)

--- a/basil/HL/keithley_2400.yaml
+++ b/basil/HL/keithley_2400.yaml
@@ -23,3 +23,9 @@ get_autorange : SOUR:CURR:RANG:AUTO?
 four_wire_on: SYST:RSEN ON
 four_wire_off: SYST:RSEN OFF
 get_remote_sense: SYST:RSEN ?
+# Special keyword for formatting query results to allow direct conversions to numeric types (e.g. float(get_current()))
+__scpi_query_fmt:
+  fmt_sep: ','
+  fmt_method:
+    get_voltage: '{0}'
+    get_current: '{1}'

--- a/basil/HL/keithley_2400.yaml
+++ b/basil/HL/keithley_2400.yaml
@@ -6,8 +6,10 @@ identifier : KEITHLEY INSTRUMENTS INC.,MODEL 2400
 on : OUTP ON
 off : OUTP OFF
 get_on: OUTP?
+get_source_current: SOUR:CURR?
 get_current : SENSE:FUNC 'CURR';:READ?
 set_current : SOUR:CURR
+get_source_voltage: SOUR:VOLT?
 set_voltage : SOUR:VOLT
 get_voltage : SENSE:FUNC 'VOLT';:READ?
 set_current_limit : SENS:CURR:PROT

--- a/basil/TL/Serial.py
+++ b/basil/TL/Serial.py
@@ -37,6 +37,11 @@ class Serial(TransferLayer):
             logger.debug(e)
         self.timeout = self._init.get('timeout', None)  # timeout of 0 returns immediately
 
+        # make interface compatible with other transfer layes (visa)
+        if "baud_rate" in self._init:
+            self._init["baudrate"] = self._init["baud_rate"]
+            del self._init["baud_rate"]
+
         self._port = serial.Serial(**{key: value for key, value in self._init.items() if key not in ("read_termination", "write_termination")})
 
     def close(self):

--- a/basil/TL/Serial.py
+++ b/basil/TL/Serial.py
@@ -38,9 +38,8 @@ class Serial(TransferLayer):
         self.timeout = self._init.get('timeout', None)  # timeout of 0 returns immediately
 
         # make interface compatible with other transfer layes (visa)
-        if "baud_rate" in self._init:
-            self._init["baudrate"] = self._init["baud_rate"]
-            del self._init["baud_rate"]
+        if "baud_rate" in self._init.keys():
+            self._init["baudrate"] = self._init.pop("baud_rate")
 
         self._port = serial.Serial(**{key: value for key, value in self._init.items() if key not in ("read_termination", "write_termination")})
 

--- a/basil/TL/Socket.py
+++ b/basil/TL/Socket.py
@@ -37,7 +37,7 @@ class Socket(TransferLayer):
         self._sock.close()
 
     def write(self, data):
-        if type(data) == bytes:
+        if isinstance(data, bytes):
             cmd = data
         else:
             cmd = data.encode(self.encoding)

--- a/basil/TL/Visa.py
+++ b/basil/TL/Visa.py
@@ -38,10 +38,9 @@ class Visa(TransferLayer):
         except NotImplementedError:  # some backends do not always implement the list_resources function
             logger.info('BASIL VISA TL with %s backend', backend)
 
-        # make interface compatible with other transfer layes (serial)
-        if "baudrate" in self._init:
-            self._init["baud_rate"] = self._init["baudrate"]
-            del self._init["baudrate"]
+        # make interface compatible with other transfer layers (serial)
+        if "baudrate" in self._init.keys():
+            self._init["baud_rate"] = self._init.pop("baudrate")
 
         self._resource = rm.open_resource(**{key: value for key, value in self._init.items() if key not in ("backend",)})
 

--- a/basil/TL/Visa.py
+++ b/basil/TL/Visa.py
@@ -38,6 +38,11 @@ class Visa(TransferLayer):
         except NotImplementedError:  # some backends do not always implement the list_resources function
             logger.info('BASIL VISA TL with %s backend', backend)
 
+        # make interface compatible with other transfer layes (serial)
+        if "baudrate" in self._init:
+            self._init["baud_rate"] = self._init["baudrate"]
+            del self._init["baudrate"]
+
         self._resource = rm.open_resource(**{key: value for key, value in self._init.items() if key not in ("backend",)})
 
     def close(self):

--- a/basil/firmware/modules/utils/CG_MOD_neg.v
+++ b/basil/firmware/modules/utils/CG_MOD_neg.v
@@ -18,7 +18,7 @@ input ck_in,enable;
 output ck_out;
 reg enl;
 
-always @(ck_in or enable)
+always_latch
 if (ck_in)
     enl = enable;
 assign ck_out = ck_in | ~enl;

--- a/basil/firmware/modules/utils/CG_MOD_pos.v
+++ b/basil/firmware/modules/utils/CG_MOD_pos.v
@@ -18,7 +18,7 @@ wire ck_inb;
 reg enl;
 
 assign ck_inb = ~ck_in;
-always @(ck_inb or enable)
+always_latch
 if (ck_inb)
     enl = enable;
 assign ck_out = ck_in & enl;

--- a/basil/utils/sim/utils.py
+++ b/basil/utils/sim/utils.py
@@ -61,7 +61,7 @@ export COCOTB=$(shell cocotb-config --share)
 #export COCOTB=$(shell SPHINX_BUILD=1 python -c "import cocotb; import os; print(os.path.dirname(os.path.dirname(os.path.abspath(cocotb.__file__))))")
 #export PYTHONPATH=$(shell python -c "from distutils import sysconfig; print(sysconfig.get_python_lib())"):$(COCOTB)
 #export LD_LIBRARY_PATH=/lib/x86_64-linux-gnu:$(PYTHONLIBS)
-export PYTHONHOME=$(shell python -c "from distutils.sysconfig import get_config_var; print(get_config_var('prefix'))")
+#export PYTHONHOME=$(shell python -c "from distutils.sysconfig import get_config_var; print(get_config_var('prefix'))")
 
 ifeq ($(SIM),questa)
     EXTRA_ARGS += $(NOT_ICARUS_DEFINES)

--- a/tests/test_SimGpio.v
+++ b/tests/test_SimGpio.v
@@ -53,12 +53,12 @@ localparam GPIO2_HIGHADDR = 16'h001f;
     assign BUS_DATA_OUT = BUS_DATA_OUT_1 | BUS_DATA_OUT_2;
 `endif
 
-/* verilator lint_off UNOPT */
+/* verilator lint_off UNOPTFLAT */
 wire [23:0] IO;
 
 assign IO[15:8] = IO[7:0];
 assign IO[23:20] = IO[19:16];
-/* verilator lint_on UNOPT */
+/* verilator lint_on UNOPTFLAT */
 
 `ifndef BASIL_SBUS
 gpio #(


### PR DESCRIPTION
Currently the baud rate init parameter is set for the serial transfer layer using `baudrate` and for the visa transfer layer using `baud_rate`.

This pull request makes these two variants interchangeable for the serial and the visa transfer layer with the aim to improve the consistency of the interface