### PR TITLE
ADD: Arduino environment/analog readout hardware layer

### DIFF
--- a/.github/workflows/regression-tests.yml
+++ b/.github/workflows/regression-tests.yml
@@ -16,7 +16,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: [3.8]
+        python-version: [3.11]
     steps:
     - uses: actions/checkout@v2
     - name: Set up Python ${{matrix.python-version}}
@@ -31,7 +31,7 @@ jobs:
   tests:
 
     name: Python ${{matrix.python-version}} | ${{matrix.sim}} 
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     env:
       SIM: ${{matrix.sim}}
 
@@ -39,24 +39,24 @@ jobs:
       fail-fast: false
       matrix:
         include:
+          - sim: icarus
+            python-version: '3.11'
 
           - sim: icarus
-            python-version: 3.7
-
-          - sim: icarus
-            python-version: 3.8
+            python-version: '3.10'
 
           - sim: verilator
-            sim-version: v4.106
-            python-version: 3.8
+            sim-version: v5.020
+            python-version: '3.10'
             pytest-marker: "-m verilator"
 
     steps:
     - uses: actions/checkout@v1
-    - uses: conda-incubator/setup-miniconda@v2
+    - name: Set up Anaconda ${{matrix.python-version}}
+      uses: conda-incubator/setup-miniconda@v2
       with:
         auto-update-conda: true
-        python-version: ${{ matrix.python-version }}
+        python-version: ${{matrix.python-version}}
 
     - name: Install Conda dependencies
       shell: bash -l {0}
@@ -67,12 +67,12 @@ jobs:
     - name: Install Python dependencies
       shell: bash -l {0}
       run: |
-        pip install pyvisa pyvisa-sim pytest coveralls pytest-cov cocotb==1.5.2
+        pip install pyvisa pyvisa-sim pytest coveralls pytest-cov cocotb>=1.8.1 cocotb-bus
   
     - name: Install Verilator
       if: matrix.sim == 'verilator'
       run: |
-        sudo apt install -y --no-install-recommends make g++ perl python3 autoconf flex bison libfl2 libfl-dev zlibc zlib1g zlib1g-dev
+        sudo apt install -y --no-install-recommends make g++ help2man perl autoconf flex bison libfl2 libfl-dev zlib1g zlib1g-dev
         git clone https://github.com/verilator/verilator.git -b ${{matrix.sim-version}}
         cd verilator
         autoconf

--- a/basil/HL/JtagMaster.py
+++ b/basil/HL/JtagMaster.py
@@ -102,7 +102,7 @@ class JtagMaster(RegisterHardwareLayer):
         bit_number = self._test_input(data)
         self.SIZE = bit_number
 
-        if type(data[0]) == BitLogic:
+        if isinstance(data[0], BitLogic):
             data_byte = self._bitlogic2bytes(data)
         else:
             data_byte = self._raw_data2bytes(data)
@@ -135,7 +135,7 @@ class JtagMaster(RegisterHardwareLayer):
             self.WORD_COUNT = bit_number // word_size
             self.SIZE = word_size
 
-        if type(data[0]) == BitLogic:
+        if isinstance(data[0], BitLogic):
             data_byte = self._bitlogic2bytes(data)
         else:
             data_byte = self._raw_data2bytes(data)

--- a/basil/HL/arduino_env_readout.py
+++ b/basil/HL/arduino_env_readout.py
@@ -15,9 +15,9 @@ class EnvironmentReadout(NTCReadout):
 
         super(EnvironmentReadout, self).__init__(intf, conf)
 
-        self.fixed_resistors = self._init.get('resistors')
-        if not isinstance(self.fixed_resistors, list):
-            self.fixed_resistors = [float(self.fixed_resistors)] * 8 if self.fixed_resistors is not None else [None] * 8
+        self.fixed_resistors = self._init.get('resistors', [10000] * 8)
+        if not isinstance(self.fixed_resistors, list) and isinstance(self.fixed_resistors, (int, float)):
+            self.fixed_resistors = [float(self.fixed_resistors)] * 8
 
         self.adc_range = float(self._init.get('adc_range', 1023))
         self.operating_voltage = float(self._init.get('operating_voltage', 5.0))

--- a/basil/HL/arduino_env_readout.py
+++ b/basil/HL/arduino_env_readout.py
@@ -1,0 +1,117 @@
+import logging
+from basil.HL.arduino_ntc_readout import NTCReadout
+
+import numpy as np
+
+logger = logging.getLogger(__name__)
+
+
+class EnvironmentReadout(NTCReadout):
+    """Class to read from Arduino temperature or humidity/pressure sensor setup"""
+
+    def __init__(self, intf, conf):
+        self.CMDS.update({
+            'analog_read': 'A'})
+        
+        super(EnvironmentReadout, self).__init__(intf, conf)
+
+        self.fixed_resistors = self._init.get('resistors')
+        if not isinstance(self.fixed_resistors, list):
+            self.fixed_resistors = [float(self.fixed_resistors)] * 8 if self.fixed_resistors is not None else [None] * 8
+
+        self.adc_range = float(self._init.get('adc_range', 1023))
+        self.operating_voltage = float(self._init.get('operating_voltage', 5.0))
+
+        self.humidity_pin = int(self._init.get('humidity_pin', -1))
+        self.pressure_pin = int(self._init.get('pressure_pin', -1))
+
+        self.steinharthart_params = dict(self._init.get('steinharthart_params', {
+            "A": 0.0,
+            "B": 0.0,
+            "C": 0.0,
+            "D": 0.0,
+            "R25": 0.0,
+        }))
+
+        self.humidity_params = dict(self._init.get('humidity_params', {
+            "slope": 0.0,
+            "offset": 0.0,
+        }))
+        
+        self.humidity_temp_correction_params = dict(self._init.get('humidity_temp_correction_params', {
+            "slope": 0.0,
+            "offset": 0.0,
+        }))
+
+        self.pressure_params = dict(self._init.get('pressure_params', {
+            "slope": 0.0,
+            "offset": 0.0,
+        }))
+
+    def setFixedResistance(self, pin, resistance):
+        self.fixed_resistors[pin] = resistance
+
+    def getResistance(self, sensor, adc_range=None):
+        analog_read = self.analog_read(sensor)
+
+        # Make int sensors to list
+        sensor = sensor if isinstance(sensor, list) else [sensor]
+
+        if adc_range is None:
+            adc_range = self.adc_range
+
+        return {s: self.fixed_resistors[s] / (adc_range / analog_read[s] - 1.0) if abs(adc_range / analog_read[s] - 1) > 0.01 else None for s in sensor}
+    
+    def getVoltage(self, sensor, adc_range=None):
+        analog_read = self.analog_read(sensor)
+        
+        # Make int sensors to list
+        sensor = sensor if isinstance(sensor, list) else [sensor]
+
+        if adc_range is None:
+            adc_range = self.adc_range
+
+        return {s: analog_read[s] * (self.operating_voltage / adc_range) for s in sensor}
+
+    def steinhartHart(self, R, A, B, C, D, R25=10e3):
+        E = np.log(R/R25)
+
+        return 1.0/(A + B*E + C*E**2 + D*E**3) - 273.15       
+
+    def temperature(self, sensor, adc_range=None):
+        # Make int sensors to list
+        sensor = sensor if isinstance(sensor, list) else [sensor]
+
+        if adc_range is None:
+            adc_range = self.adc_range
+            
+        resistances = self.getResistance(sensor, adc_range)
+
+        return {s: self.steinhartHart(resistances[s], **self.steinharthart_params) if resistances[s] is not None else None for s in sensor}
+    
+    def humidity(self, temperature_correction=None, adc_range=None):
+        if self.humidity_pin < 0:
+            logger.warning('No humidity pin specified!')
+            return
+        
+        voltage = self.getVoltage(self.humidity_pin, adc_range)[self.humidity_pin]
+
+        RH = (voltage - self.humidity_params['offset']) / self.humidity_params['slope']
+
+        if temperature_correction is not None:
+            RH = RH / (self.humidity_temp_correction_params['slope'] * temperature_correction + self.humidity_temp_correction_params['offset'])
+
+        return max(float(RH), 0.0)
+    
+    def pressure(self, adc_range=None):
+        if self.pressure_pin < 0:
+            logger.warning('No pressure pin specified!')
+            return
+        
+        voltage = self.getVoltage(self.pressure_pin, adc_range)[self.pressure_pin]
+
+        return self.pressure_params['slope'] * voltage - self.pressure_params['offset'];
+    
+    def analog_read(self, sensor):
+        return self._get_measurement(sensor, kind='analog_read')
+    

--- a/basil/HL/arduino_env_readout.py
+++ b/basil/HL/arduino_env_readout.py
@@ -48,10 +48,10 @@ class EnvironmentReadout(NTCReadout):
             "offset": 0.0,
         }))
 
-    def setFixedResistance(self, pin, resistance):
+    def set_fixed_resistance(self, pin, resistance):
         self.fixed_resistors[pin] = resistance
 
-    def getResistance(self, sensor, adc_range=None):
+    def get_resistance(self, sensor, adc_range=None):
         analog_read = self.analog_read(sensor)
 
         # Make int sensors to list
@@ -62,7 +62,7 @@ class EnvironmentReadout(NTCReadout):
 
         return {s: self.fixed_resistors[s] / (adc_range / analog_read[s] - 1.0) if abs(adc_range / analog_read[s] - 1) > 0.01 else None for s in sensor}
 
-    def getVoltage(self, sensor, adc_range=None):
+    def get_voltage(self, sensor, adc_range=None):
         analog_read = self.analog_read(sensor)
 
         # Make int sensors to list
@@ -73,7 +73,7 @@ class EnvironmentReadout(NTCReadout):
 
         return {s: analog_read[s] * (self.operating_voltage / adc_range) for s in sensor}
 
-    def steinhartHart(self, R, A, B, C, D, R25=10e3):
+    def steinharthart(self, R, A, B, C, D, R25=10e3):
         E = np.log(R / R25)
 
         return 1.0 / (A + B * E + C * E**2 + D * E**3) - 273.15
@@ -85,16 +85,16 @@ class EnvironmentReadout(NTCReadout):
         if adc_range is None:
             adc_range = self.adc_range
 
-        resistances = self.getResistance(sensor, adc_range)
+        resistances = self.get_resistance(sensor, adc_range)
 
-        return {s: self.steinhartHart(resistances[s], **self.steinharthart_params) if resistances[s] is not None else None for s in sensor}
+        return {s: self.steinharthart(resistances[s], **self.steinharthart_params) if resistances[s] is not None else None for s in sensor}
 
     def humidity(self, temperature_correction=None, adc_range=None):
         if self.humidity_pin < 0:
             logger.warning('No humidity pin specified!')
             return
 
-        voltage = self.getVoltage(self.humidity_pin, adc_range)[self.humidity_pin]
+        voltage = self.get_voltage(self.humidity_pin, adc_range)[self.humidity_pin]
 
         RH = (voltage - self.humidity_params['offset']) / self.humidity_params['slope']
 
@@ -108,7 +108,7 @@ class EnvironmentReadout(NTCReadout):
             logger.warning('No pressure pin specified!')
             return
 
-        voltage = self.getVoltage(self.pressure_pin, adc_range)[self.pressure_pin]
+        voltage = self.get_voltage(self.pressure_pin, adc_range)[self.pressure_pin]
 
         return self.pressure_params['slope'] * voltage - self.pressure_params['offset']
 

--- a/basil/HL/keithley_2400.yaml
+++ b/basil/HL/keithley_2400.yaml
@@ -23,3 +23,9 @@ get_autorange : SOUR:CURR:RANG:AUTO?
 four_wire_on: SYST:RSEN ON
 four_wire_off: SYST:RSEN OFF
 get_remote_sense: SYST:RSEN ?
+# Special keyword for formatting query results to allow direct conversions to numeric types (e.g. float(get_current()))
+__scpi_query_fmt:
+  fmt_sep: ','
+  fmt_method:
+    get_voltage: '{0}'
+    get_current: '{1}'

--- a/basil/HL/keithley_2400.yaml
+++ b/basil/HL/keithley_2400.yaml
@@ -6,8 +6,10 @@ identifier : KEITHLEY INSTRUMENTS INC.,MODEL 2400
 on : OUTP ON
 off : OUTP OFF
 get_on: OUTP?
+get_source_current: SOUR:CURR?
 get_current : SENSE:FUNC 'CURR';:READ?
 set_current : SOUR:CURR
+get_source_voltage: SOUR:VOLT?
 set_voltage : SOUR:VOLT
 get_voltage : SENSE:FUNC 'VOLT';:READ?
 set_current_limit : SENS:CURR:PROT

--- a/basil/TL/Socket.py
+++ b/basil/TL/Socket.py
@@ -37,7 +37,7 @@ class Socket(TransferLayer):
         self._sock.close()
 
     def write(self, data):
-        if type(data) == bytes:
+        if isinstance(data, bytes):
             cmd = data
         else:
             cmd = data.encode(self.encoding)

--- a/basil/firmware/arduino/EnvironmentReadout/EnvironmentReadout.ino
+++ b/basil/firmware/arduino/EnvironmentReadout/EnvironmentReadout.ino
@@ -1,0 +1,366 @@
+/*
+------------------------------------------------------------
+Copyright (c) All rights reserved
+SiLab, Institute of Physics, University of Bonn
+-----------------------------------------------------------
+Using the Arduino Nano as temperature sensor via voltage divider and NTC thermistor.
+Every analog pin is connected to read the voltage over a thermistor, therefore up to 8
+temperature values can be recorded.
+*/
+
+// Define constants
+const float KELVIN = 273.15; // Kelvin
+const int SAMPLE_DELAY_US = 50; // Microseconds delay between two measurement samples
+const int NTC_PINS [] = {A0, A1, A2, A3, A4, A5, A6, A7}; // Array of analog input pins on Arduino
+
+// Default values
+const int N_SAMPLES = 5; // Average each temperature value over N_SAMPLES analog reads
+const uint16_t SERIAL_DELAY_MILLIS = 1; // Delay between Serial.available() checks
+const float NTC_NOMINAL_RES = 10000.0; // Resistance of NTC at 25 degrees C
+const float RESISTOR_RES = 10000.0; // Resistance of the resistors in series to the NTC, forming voltage divider
+const float TEMP_NOMINAL_DEGREE_C = 25.0; // Nominal temperature for above resistance (almost always 25 C)
+const float BETA_COEFFICIENT = 3950.0; // The beta coefficient of the NTC (usually 3000-4000); EPC B57891-M103 NTC Thermistor
+const uint16_t MEAS_OVER_NTC = 1; // Whether the voltage drop in the divider configuration is measured over the NTC. If 0, then it is measured over the fixed resistor
+
+// Serial related
+const char END = '\n';
+const uint8_t END_PEEK = int(END); // Serial.peek returns byte as dtype int
+const char DELIM = ':';
+const char NULL_TERM = '\0';
+size_t nProcessedBytes;
+const size_t BUF_SIZE = 32;
+char serialBuffer[BUF_SIZE]; // Max buffer 32 bytes in incoming serial data
+
+
+// Commands
+const char TEMP_CMD = 'T';
+const char RES_CMD = 'Q';
+const char DELAY_CMD = 'D';
+const char SAMPLE_CMD = 'S';
+const char BETA_CMD = 'B';
+const char NOMINAL_RES_CMD = 'O';
+const char NOMINAL_TEMP_CMD = 'C';
+const char RESISTANCE_CMD = 'R';
+const char RESET_CMD = 'X';
+const char MEAS_OVER_NTC_CMD = 'Y';
+const char ANALAOG_READ_CMD = 'A';
+
+
+// Define variables to be used for calculation
+float temperature;
+float resistance;
+float val;
+int ntcPin;
+bool oneLastProcess;
+
+
+// Define vars potentially coming in from serial
+int nSamples;
+uint16_t serialDelayMillis; 
+float ntcNominalRes;
+float resistorRes;
+float tempNominalDegreeC;
+float betaCoefficient;
+uint16_t measureOverNTC;
+
+
+void restoreDefaults(){
+  /*
+  Resores default values of all variables that potentially come in over serial
+  */
+  nSamples = N_SAMPLES;
+  serialDelayMillis = SERIAL_DELAY_MILLIS;
+  ntcNominalRes = NTC_NOMINAL_RES;
+  resistorRes = RESISTOR_RES;
+  tempNominalDegreeC = TEMP_NOMINAL_DEGREE_C;
+  betaCoefficient = BETA_COEFFICIENT;
+  measureOverNTC = MEAS_OVER_NTC;
+}
+
+
+float steinhartHartNTC(float res){
+  /*
+  Steinhart-Hart equation for NTC: 1/T = 1/T_0 + 1/B * ln(R/R_0)  
+  */
+
+  // Do calculation
+  temperature = 1.0 / (1.0 / (tempNominalDegreeC + KELVIN) + 1.0 / betaCoefficient * log(res / ntcNominalRes));
+
+  // To Kelvin
+  temperature -= KELVIN;
+  
+  return temperature;
+}
+
+
+float getRes(int ntc){
+  /*
+  Reads the voltage from analog pin *ntc_pin* in ADC units and converts them to resistance.
+  */
+
+  // Reset resitance
+  resistance = 0;
+
+  // take N samples in a row, with a slight delay
+  for (int i=0; i< nSamples; i++){
+    resistance += analogRead(ntc);
+    delayMicroseconds(SAMPLE_DELAY_US);
+  }
+
+  // Do the average
+  resistance /= nSamples;
+
+  // Convert  ADC resistance value to resistance in Ohm
+  resistance = 1023.0 / resistance - 1.0;
+
+  // Voltage divider is measured over the NTC with NTC_NOMINAL_RES
+  if (measureOverNTC > 0) {
+    resistance = resistorRes / resistance;
+  }
+
+  // Voltage divider is measured over the fixed RESISTOR_RES
+  else {
+    resistance = resistorRes * resistance;  
+  }
+
+  return resistance;
+}
+
+float getAnalogRead(int ntc){
+  /*
+  Reads from analog pin *ntc_pin* in ADC units and converts them to a voltage.
+  */
+
+  // Reset value
+  val = 0;
+
+  // take N samples in a row, with a slight delay
+  for (int i=0; i< nSamples; i++){
+    val += analogRead(ntc);
+    delayMicroseconds(SAMPLE_DELAY_US);
+  }
+
+  // Do the average
+  val /= nSamples;
+  
+  return val;
+}
+
+
+float getTemp(int ntc){
+  /*
+  Reads the voltage from analog pin *ntc_pin* in ADC units and converts them to resistance.
+  Returns the temperature calculated from Steinhart-Hart-Equation
+  */
+  return steinhartHartNTC(getRes(ntc));
+}
+
+
+uint8_t processIncoming(){
+
+  // We have reached the end of the transmission; clear serial by calling read
+  if (Serial.peek() == END_PEEK){
+    Serial.read();
+    serialBuffer[0] = NULL_TERM;
+    return 0;
+  }
+  else {
+    // Read to buffer until delimiter
+    nProcessedBytes = Serial.readBytesUntil(DELIM, serialBuffer, BUF_SIZE);
+
+    // Null-terminate string
+    serialBuffer[nProcessedBytes] = NULL_TERM;
+    return 1;
+  }
+}
+
+
+void printNTCMeasurements(int kind){
+  /*
+  Read the input buffer, read pins to read and print the respective temp or resistance to serial
+  */
+  
+  while (processIncoming()){
+  
+    ntcPin = atoi(serialBuffer);
+
+    // We only have 8 analog pins
+    if (0 <= ntcPin && ntcPin < 8) {
+      if (kind == 0) {
+        // Send out tempertaure in C, two decimal places, wait
+        Serial.println(getTemp(NTC_PINS[ntcPin]), 2);
+      } else if (kind == 1) {
+        // Send out resitance in Ohm, two decimal places, wait
+        Serial.println(getRes(NTC_PINS[ntcPin]));
+      } else if (kind == 2) {
+        Serial.println(getAnalogRead(NTC_PINS[ntcPin]));
+      }
+      delay(50);
+    }
+    else {
+      // Pin out of range
+      Serial.println(999);
+    }
+  }
+}
+
+
+void resetIncoming(){
+  // Wait 500 ms and clear the incoming data
+  delay(500);
+  while(Serial.available()){
+    Serial.read();
+  }
+}
+
+
+void setup(void){
+  /*
+   * initiliaze with external ref voltage
+   * initialize Serial communication with baudrate Serial.begin(<baudrate>)
+   * delay 500ms to let connections and possible setups to be established
+   */
+  restoreDefaults(); // Restore default values
+  Serial.begin(115200); // Initialize serial connection
+  analogReference(EXTERNAL); // Set 3.3V as external reference voltage instead of internal 5V reference
+  delay(500);
+}
+
+
+void loop(void){
+
+  // Get input from serial connection
+  if (Serial.available()){
+
+    processIncoming();
+    oneLastProcess = true;
+
+    // First processing should yield a single char because it the cmd
+    if (strlen(serialBuffer) == 1){
+
+      // Lowercase means we want to set some value and print back that value on the serial bus
+      if (isLowerCase(serialBuffer[0])){
+
+        // Set number of samples
+        if (toupper(serialBuffer[0]) == SAMPLE_CMD){
+          processIncoming();
+          nSamples = atoi(serialBuffer);
+          Serial.println(nSamples);
+        }
+
+        // Set serial dealy in millis
+        if (toupper(serialBuffer[0]) == DELAY_CMD){
+          processIncoming();
+          serialDelayMillis = atoi(serialBuffer);
+          Serial.println(serialDelayMillis);
+        }
+
+        // Set beta coefficient in Kelvin
+        if (toupper(serialBuffer[0]) == BETA_CMD){
+          processIncoming();
+          betaCoefficient = atof(serialBuffer);
+          Serial.println(betaCoefficient);
+        }
+
+        // Set nominal resistance in Ohm
+        if (toupper(serialBuffer[0]) == NOMINAL_RES_CMD){
+          processIncoming();
+          ntcNominalRes = atof(serialBuffer);
+          Serial.println(ntcNominalRes);
+        }
+
+        // Set nominal temp in Celsius
+        if (toupper(serialBuffer[0]) == NOMINAL_TEMP_CMD){
+          processIncoming();
+          tempNominalDegreeC = atof(serialBuffer);
+          Serial.println(tempNominalDegreeC);
+        }
+
+        // Set resistance of resistor in voltage divider config in Ohm
+        if (toupper(serialBuffer[0]) == RESISTANCE_CMD){
+          processIncoming();
+          resistorRes = atof(serialBuffer);
+          Serial.println(resistorRes);
+        }
+
+        // Set whether we measure the voltage over the NTC or the fixed resistor in voltage divider config
+        if (toupper(serialBuffer[0]) == MEAS_OVER_NTC_CMD){
+          processIncoming();
+          measureOverNTC = atoi(serialBuffer);
+          Serial.println(measureOverNTC);
+        }
+
+        // Restore all variables to their default value
+        if (toupper(serialBuffer[0]) == RESET_CMD){
+          restoreDefaults();
+          processIncoming();
+          Serial.println(atoi(serialBuffer)); // Test response
+        }
+
+      }
+
+      else {
+
+        if (serialBuffer[0] == TEMP_CMD){
+          printNTCMeasurements(0); // Temperature
+          oneLastProcess = false;
+        }
+
+        if (serialBuffer[0] == RES_CMD){
+          printNTCMeasurements(1); // Resistance
+          oneLastProcess = false;
+        }
+
+        if (serialBuffer[0] == ANALAOG_READ_CMD){
+          printNTCMeasurements(2); // Analog value
+          oneLastProcess = false;
+        }
+
+        // Return serial delay millis
+        if (serialBuffer[0] == DELAY_CMD){
+          Serial.println(serialDelayMillis);
+        }
+
+        // Return number of samples
+        if (serialBuffer[0] == SAMPLE_CMD){
+          Serial.println(nSamples);
+        }
+
+        // Return beta coefficient in Kelvin
+        if (serialBuffer[0] == BETA_CMD){
+          Serial.println(betaCoefficient);
+        }
+
+        // Return nominal ntc resistance at nominal temp in Ohm
+        if (serialBuffer[0] == NOMINAL_RES_CMD){
+          Serial.println(ntcNominalRes);
+        }
+
+        // Return nominal ntc temp in Celsius
+        if (serialBuffer[0] == NOMINAL_TEMP_CMD){
+          Serial.println(tempNominalDegreeC);
+        }
+
+        // Return resistor value in voltage divider config in Ohm
+        if (serialBuffer[0] == RESISTANCE_CMD){
+          Serial.println(resistorRes);
+        }
+
+        // Return whether we measure over the NTC or fixed resistor
+        if (serialBuffer[0] == MEAS_OVER_NTC_CMD){
+          Serial.println(measureOverNTC);
+        }
+
+      }
+
+      if (oneLastProcess){
+        processIncoming();
+      }
+
+    } else{
+      Serial.println("error");
+      // resetIncoming(); //Does not do what I want
+    }
+  }
+  delay(serialDelayMillis);
+}

--- a/basil/firmware/arduino/EnvironmentReadout/Readme.rst
+++ b/basil/firmware/arduino/EnvironmentReadout/Readme.rst
@@ -1,0 +1,10 @@
+======================================
+Arduino Firmware for Environment Readout (temperature, humidity/pressure)
+======================================
+
+Arduino Nano firmware to read out NTCs via the 8 analog input pins A0 to A7 and the internal (multiplexed) ADC.
+
+NTC inputs require a voltage divider configuration, supplied with the 3.3 V Arduino rail.The voltage drop over the NTC is the input to the analog pin.
+The conversion from ADC value to degree Celsius can take place in the firmware.
+
+Additionally, a pure analog read out is possible for processing of humidity and pressure sensors.

--- a/basil/firmware/modules/utils/CG_MOD_neg.v
+++ b/basil/firmware/modules/utils/CG_MOD_neg.v
@@ -18,7 +18,7 @@ input ck_in,enable;
 output ck_out;
 reg enl;
 
-always @(ck_in or enable)
+always_latch
 if (ck_in)
     enl = enable;
 assign ck_out = ck_in | ~enl;

--- a/basil/firmware/modules/utils/CG_MOD_pos.v
+++ b/basil/firmware/modules/utils/CG_MOD_pos.v
@@ -18,7 +18,7 @@ wire ck_inb;
 reg enl;
 
 assign ck_inb = ~ck_in;
-always @(ck_inb or enable)
+always_latch
 if (ck_inb)
     enl = enable;
 assign ck_out = ck_in & enl;

--- a/basil/utils/sim/utils.py
+++ b/basil/utils/sim/utils.py
@@ -61,7 +61,7 @@ export COCOTB=$(shell cocotb-config --share)
 #export COCOTB=$(shell SPHINX_BUILD=1 python -c "import cocotb; import os; print(os.path.dirname(os.path.dirname(os.path.abspath(cocotb.__file__))))")
 #export PYTHONPATH=$(shell python -c "from distutils import sysconfig; print(sysconfig.get_python_lib())"):$(COCOTB)
 #export LD_LIBRARY_PATH=/lib/x86_64-linux-gnu:$(PYTHONLIBS)
-export PYTHONHOME=$(shell python -c "from distutils.sysconfig import get_config_var; print(get_config_var('prefix'))")
+#export PYTHONHOME=$(shell python -c "from distutils.sysconfig import get_config_var; print(get_config_var('prefix'))")
 
 ifeq ($(SIM),questa)
     EXTRA_ARGS += $(NOT_ICARUS_DEFINES)

--- a/tests/test_SimGpio.v
+++ b/tests/test_SimGpio.v
@@ -53,12 +53,12 @@ localparam GPIO2_HIGHADDR = 16'h001f;
     assign BUS_DATA_OUT = BUS_DATA_OUT_1 | BUS_DATA_OUT_2;
 `endif
 
-/* verilator lint_off UNOPT */
+/* verilator lint_off UNOPTFLAT */
 wire [23:0] IO;
 
 assign IO[15:8] = IO[7:0];
 assign IO[23:20] = IO[19:16];
-/* verilator lint_on UNOPT */
+/* verilator lint_on UNOPTFLAT */
 
 `ifndef BASIL_SBUS
 gpio #(


### PR DESCRIPTION
An Arduino firmware based on the NTC readout firmware has been added to read out the pure analog values. This firmware helps to standardize experimental setups with multiple Arduino readout boards by moving the temperature/humidity/pressure calculation to the 'EnvironmentReadout' class instances in the hardware drivers list. It can also reduce the number of different Arduino firmwares required for larger setups to one.
This step was also necessary for temperature-corrected humidity measurements in more extreme measurement ranges.

The `EnvironmentReadout` class has readout functions for temperature, humidity and pressure. The calibration/conversion parameters can be set as init parameters of the corresponding hardware driver, as follows:

```
hw_drivers:
  - name      : ReadoutEnvHumPres
    type      : arduino_env_readout
    interface : ArduinoBoardEnv
    init :
      ntc_limits : [-55, 70]
      resistors: 51100
      pressure_pin: 7
      humidity_pin: 6
      humidity_params:
        slope: 0.031483
        offset: 0.826
      humidity_temp_correction_params:
        slope: -0.00216
        offset: 1.0546
      pressure_params:
        slope: 27.6
        offset: 33.45
```

TL;DR: These changes simplify the readout of multiple Arduino "Environment" boards by moving the hardware-dependent calibration constants to the hardware driver configuration as an init parameter. The conversion from analog readout to temperature/humidity/pressure measurement is done by the hardware driver.

Optional improvements:
- [  ] Allow multiple humidity/pressure pins 
