### PR TITLE
ENH: get_die now outputs the unmodified die position from the prober api

### DIFF
--- a/basil/HL/SentioProber.py
+++ b/basil/HL/SentioProber.py
@@ -51,7 +51,7 @@ class SentioProber(HardwareLayer):
         reply = self._intf.query("map:die:get_current_index").strip()
         if reply == '0:' or reply == '':
             reply = self._intf.query("map:die:get_current_index")
-            
+
         values = reply[2:].split(',')
 
         return (int(values[0]), int(values[1]))

--- a/basil/HL/SentioProber.py
+++ b/basil/HL/SentioProber.py
@@ -48,9 +48,13 @@ class SentioProber(HardwareLayer):
 
     def get_die(self):
         ''' Get chip index '''
-        print("Check if return order of col and row is correct and consistent with other pc drivers.")
-        values = self._intf.query("map:die:get_current_index").split(",")
-        print(int(values[-2]), int(values[-1]))
+        reply = self._intf.query("map:die:get_current_index").strip()
+        if reply == '0:' or reply == '':
+            reply = self._intf.query("map:die:get_current_index")
+            
+        values = reply[2:].split(',')
+
+        return (int(values[0]), int(values[1]))
 
     def contact(self):
         ''' Move chuck to contact z position'''

--- a/basil/HL/SignatoneProber.py
+++ b/basil/HL/SignatoneProber.py
@@ -39,9 +39,11 @@ class SignatoneProber(HardwareLayer):
                 reply = self._intf.query('GETCR')
             else:
                 break
+        
         reply = re.sub(r'[a-zA-Z]', r'', reply)
         values = reply.split(',')
-        return (abs(int(values[0])), abs(int(values[1])))
+        
+        return (int(values[0]), int(values[1]))
 
     def contact(self):
         ''' Move chuck to contact z position'''

--- a/basil/HL/SignatoneProber.py
+++ b/basil/HL/SignatoneProber.py
@@ -39,10 +39,10 @@ class SignatoneProber(HardwareLayer):
                 reply = self._intf.query('GETCR')
             else:
                 break
-        
+
         reply = re.sub(r'[a-zA-Z]', r'', reply)
         values = reply.split(',')
-        
+
         return (int(values[0]), int(values[1]))
 
     def contact(self):


### PR DESCRIPTION
Removed custom die position mappings.

get_die() now outputs the direct response from the prober api.