### PR TITLE
Support for existing firmware projections and new simulation API

### DIFF
--- a/basil/firmware/modules/utils/CG_MOD_neg.v
+++ b/basil/firmware/modules/utils/CG_MOD_neg.v
@@ -18,7 +18,7 @@ input ck_in,enable;
 output ck_out;
 reg enl;
 
-always_latch
+always @(ck_in or enable)
 if (ck_in)
     enl = enable;
 assign ck_out = ck_in | ~enl;

--- a/basil/firmware/modules/utils/CG_MOD_pos.v
+++ b/basil/firmware/modules/utils/CG_MOD_pos.v
@@ -18,9 +18,11 @@ wire ck_inb;
 reg enl;
 
 assign ck_inb = ~ck_in;
-always_latch
+
+always @(ck_inb or enable)
 if (ck_inb)
     enl = enable;
+
 assign ck_out = ck_in & enl;
 
 endmodule


### PR DESCRIPTION
Add back support to synthesize existing firmware projects by removing the SystemVerilog `always_latch` statements in two modules.
At the same time, adapt to new(er) `cocotb` usage.