### PR TITLE
Fix firmware compilation error

### DIFF
--- a/basil/firmware/modules/utils/CG_MOD_neg.v
+++ b/basil/firmware/modules/utils/CG_MOD_neg.v
@@ -18,9 +18,12 @@ input ck_in,enable;
 output ck_out;
 reg enl;
 
+// verilator lint_off LATCH
 always @(ck_in or enable)
 if (ck_in)
     enl = enable;
+// verilator lint_on LATCH
+
 assign ck_out = ck_in | ~enl;
 
 endmodule

--- a/basil/firmware/modules/utils/CG_MOD_neg.v
+++ b/basil/firmware/modules/utils/CG_MOD_neg.v
@@ -18,7 +18,7 @@ input ck_in,enable;
 output ck_out;
 reg enl;
 
-always_latch
+always @(ck_in or enable)
 if (ck_in)
     enl = enable;
 assign ck_out = ck_in | ~enl;

--- a/basil/firmware/modules/utils/CG_MOD_pos.v
+++ b/basil/firmware/modules/utils/CG_MOD_pos.v
@@ -18,9 +18,11 @@ wire ck_inb;
 reg enl;
 
 assign ck_inb = ~ck_in;
-always_latch
+
+always @(ck_inb or enable)
 if (ck_inb)
     enl = enable;
+
 assign ck_out = ck_in & enl;
 
 endmodule

--- a/basil/firmware/modules/utils/CG_MOD_pos.v
+++ b/basil/firmware/modules/utils/CG_MOD_pos.v
@@ -19,9 +19,11 @@ reg enl;
 
 assign ck_inb = ~ck_in;
 
+// verilator lint_off LATCH
 always @(ck_inb or enable)
 if (ck_inb)
     enl = enable;
+// verilator lint_on LATCH
 
 assign ck_out = ck_in & enl;
 


### PR DESCRIPTION
This PR fixes #219, removing the SystemVerilog `always_latch` statement that crashes existing firmware projects where the respective files are listed in the included modules in Vivado.
The verilator metacomment disables the warning that is raised at compilation time which stops execution of the test.

In a future (major) version, the SystemVerilog syntax should be adopted and the files renamed to `*.sv` which requires changes in depending firmware projects.