### PR TITLE
Fix deprecation errors/warnings

### DIFF
--- a/basil/__init__.py
+++ b/basil/__init__.py
@@ -1,4 +1,4 @@
-from pkg_resources import get_distribution, DistributionNotFound
+from importlib.metadata import version, PackageNotFoundError
 import collections
 import yaml
 
@@ -6,8 +6,8 @@ import yaml
 __version__ = None  # required for initial installation
 
 try:
-    __version__ = get_distribution("basil_daq").version
-except DistributionNotFound:
+    __version__ = version("basil_daq")
+except PackageNotFoundError:
     __version__ = "(local)"
 
 

--- a/examples/mio_sram_test/tests/test_Sim.py
+++ b/examples/mio_sram_test/tests/test_Sim.py
@@ -143,7 +143,7 @@ class TestSram(unittest.TestCase):
         self.chip['PULSE'].start()
 
         ret = self.chip['FIFO'].get_data()
-        x = np.arange((128 + 1023) * 4, (128 + 1023 + 1) * 4, dtype=np.uint8)
+        x = np.arange((128 + 1023) * 4, (128 + 1023 + 1) * 4).astype(np.uint8)
         x.dtype = np.uint32
 
         np.testing.assert_array_equal(ret, x)
@@ -197,12 +197,12 @@ class TestSram(unittest.TestCase):
         for _ in range(100):
             ret = self.chip['FIFO'].get_data()
 
-            x = np.arange(i * 4, (i + ret.shape[0]) * 4, dtype=np.uint8)
+            x = np.arange(i * 4, (i + ret.shape[0]) * 4).astype(np.uint8)
             x.dtype = np.uint32
 
             i += ret.shape[0]
 
-            ok = np.alltrue(ret == x)
+            ok = np.all(ret == x)
             # print 'OK?', ok, ret.shape[0], i, k
             if not ok:
                 error = True

--- a/setup.py
+++ b/setup.py
@@ -34,7 +34,7 @@ def package_files(directory):
 setup(
     name='basil_daq',
     version=version,
-    python_requires='>=3.7',
+    python_requires='>=3.8',
     description='Basil - a data acquisition and system testing framework',
     url='https://github.com/SiLab-Bonn/basil',
     license='BSD 3-Clause ("BSD New" or "BSD Simplified") License',


### PR DESCRIPTION
Fixes _pkg_resources_ deprecation that is also relevant for importing basil and numpy casting deprecation in tests. The former effectively raises the minimum python version to 3.8, which makes sense anyway, given the support from large packages such as numpy and scipy.