### PR TITLE
MAINT: Prevent OverflowError in multiplication

### DIFF
--- a/basil/utils/utils.py
+++ b/basil/utils/utils.py
@@ -41,7 +41,7 @@ def bitarray_to_byte_array(bitarr):
     ba = bitarray(bitarr, endian=bitarr.endian())
     ba.reverse()  # this flip the byte order and the bit order of each byte
     bs = np.frombuffer(ba.tobytes(), dtype=np.uint8)  # byte padding happens here, bitarray.tobytes()
-    bs = (bs.astype(np.uint64) * 0x0202020202 & 0x010884422010) % 1023
+    bs = (bs * np.uint64(0x0202020202) & 0x010884422010) % 1023
     return array('B', bs.astype(np.uint8))
 
 

--- a/basil/utils/utils.py
+++ b/basil/utils/utils.py
@@ -41,7 +41,7 @@ def bitarray_to_byte_array(bitarr):
     ba = bitarray(bitarr, endian=bitarr.endian())
     ba.reverse()  # this flip the byte order and the bit order of each byte
     bs = np.frombuffer(ba.tobytes(), dtype=np.uint8)  # byte padding happens here, bitarray.tobytes()
-    bs = (bs * 0x0202020202 & 0x010884422010) % 1023
+    bs = (bs.astype(np.uint64) * 0x0202020202 & 0x010884422010) % 1023
     return array('B', bs.astype(np.uint8))
 
 


### PR DESCRIPTION
In newer numpy versions the multiplication of ndarrays containing uint8 results in uint8. Here this leads to an OverflowError. Therefore changing to an uint64 before the multiplication prevents this.