### PR TITLE
Refactored iseg hardware layer

### DIFF
--- a/basil/HL/iseg_hv.py
+++ b/basil/HL/iseg_hv.py
@@ -504,7 +504,7 @@ class IsegHV(HardwareLayer):
         return self.identifier().split(";")[3]
 
     # BEWLOW DEPRECATED
-    
+
     @property
     def hv_on(self):
         """

--- a/basil/HL/iseg_hv.py
+++ b/basil/HL/iseg_hv.py
@@ -223,7 +223,7 @@ class IsegHV(HardwareLayer):
             int(self._get_set_property(prop="get_current_limit")) / 100.0 * float(self.I_MAX[:-2])
         )
 
-    def set_current_trip(self, resolution="mA"):
+    def get_current_trip(self, resolution="mA"):
         """
         Read current trip/limit, if 0 -> no trip
 
@@ -475,14 +475,18 @@ class IsegHV(HardwareLayer):
     def get_on(self):
         return "0" if self.get_module_status()[4] == "1" else "1"
 
-    def set_voltage_range(self): ...  # Not implemented
+    def set_voltage_range(self): # Not implemented
+        ...
 
-    def set_current(self): ...  # Not implemented
+    def set_current(self): # Not implemented
+        ...
 
-    def source_current(self): ...  # Not implemented
+    def source_current(self): # Not implemented
+        ...
 
-    def soruce_volt(self): ...  # Not implemented
-
+    def soruce_volt(self): # Not implemented
+        ...
+        
     @property
     def UNIT_NUMBER(self):
         return self.identifier().split(";")[0]
@@ -499,7 +503,7 @@ class IsegHV(HardwareLayer):
     def I_MAX(self):
         return self.identifier().split(";")[3]
 
-    ##### BEWLOW DEPRECATED #####
+    #### BEWLOW DEPRECATED ####
 
     @property
     def hv_on(self):

--- a/basil/HL/iseg_hv.py
+++ b/basil/HL/iseg_hv.py
@@ -108,12 +108,12 @@ class IsegHV(HardwareLayer):
         self.ERRORS[f"? UMAX={self.get_voltage_limit}"] = (
             "Set voltage exceeds voltage limit"
         )
-        
+
         self.set_autostart(self._autostart)
-        
+
     def set_high_voltage(self, voltage):
         self.high_voltage = voltage
-        
+
     def get_high_voltage(self):
         return self.high_voltage
 

--- a/basil/HL/iseg_hv.py
+++ b/basil/HL/iseg_hv.py
@@ -475,18 +475,18 @@ class IsegHV(HardwareLayer):
     def get_on(self):
         return "0" if self.get_module_status()[4] == "1" else "1"
 
-    def set_voltage_range(self): # Not implemented
+    def set_voltage_range(self):  # Not implemented
         ...
 
-    def set_current(self): # Not implemented
+    def set_current(self):  # Not implemented
         ...
 
-    def source_current(self): # Not implemented
+    def source_current(self):  # Not implemented
         ...
 
-    def soruce_volt(self): # Not implemented
+    def soruce_volt(self):  # Not implemented
         ...
-        
+
     @property
     def UNIT_NUMBER(self):
         return self.identifier().split(";")[0]
@@ -503,8 +503,8 @@ class IsegHV(HardwareLayer):
     def I_MAX(self):
         return self.identifier().split(";")[3]
 
-    #### BEWLOW DEPRECATED ####
-
+    # BEWLOW DEPRECATED
+    
     @property
     def hv_on(self):
         """

--- a/basil/HL/iseg_hv.py
+++ b/basil/HL/iseg_hv.py
@@ -21,85 +21,102 @@ class IsegHV(HardwareLayer):
 
     # Command references from protocol
     CMDS = {
-        'get_identifier': '#',
-        'set_answer_delay': 'W={value}',
-        'get_answer_delay': 'W',
-        'get_voltage_meas': 'U{channel}',
-        'get_current_meas': 'I{channel}',
-        'get_v_lim': 'M{channel}',
-        'get_i_lim': 'N{channel}',
-        'get_voltage_set': 'D{channel}',
-        'set_voltage': 'D{channel}={value}',
-        'get_ramp_speed': 'V{channel}',
-        'set_ramp_speed': 'V{channel}={value}',
-        'start_voltage_ramp': 'G{channel}',
-        'set_current_trip': 'L{channel}={value}',
-        'get_current_trip': 'L{channel}',
-        'get_status_word': 'S{channel}',
-        'get_module_status': 'T{channel}',
-        'set_autostart': 'A{channel}={value}',
-        'get_autostart': 'A{channel}'
+        "get_identifier": "#",
+        "set_answer_delay": "W={value}",
+        "get_answer_delay": "W",
+        "get_voltage": "U{channel}",
+        "get_current": "I{channel}",
+        "get_voltage_limit": "M{channel}",
+        "get_current_limit": "N{channel}",
+        "get_source_voltage": "D{channel}",
+        "set_voltage": "D{channel}={value}",
+        "get_ramp_speed": "V{channel}",
+        "set_ramp_speed": "V{channel}={value}",
+        "start_voltage_ramp": "G{channel}",
+        "set_current_trip": "L{channel}={value}",  # Same functionality as set_current_trip_mA
+        "get_current_trip": "L{channel}",  # Same functionality as get_current_trip_mA
+        "set_current_trip_mA": "LB{channel}={value}",
+        "get_current_trip_mA": "LB{channel}",
+        "set_current_trip_muA": "LS{channel}={value}",
+        "get_current_trip_muA": "LS{channel}",
+        "get_status_word": "S{channel}",
+        "get_module_status": "T{channel}",
+        "set_autostart": "A{channel}={value}",
+        "get_autostart": "A{channel}",
     }
 
     FORMATS = {
-        'get_voltage_meas': lambda val: f'{val[:-3]}e{val[-3:]}',
-        'get_current_meas': lambda val: f'{val[:-3]}e{val[-3:]}',
-        'get_voltage_set': lambda val: f'{val[:-3]}e{val[-3:]}',
-        'get_current_trip': lambda val: f'{val[:-3]}e{val[-3:]}'
+        "get_voltage_meas": lambda val: f"{val[:-3]}e{val[-3:]}",
+        "get_current_meas": lambda val: f"{val[:-3]}e{val[-3:]}",
+        "get_voltage_set": lambda val: f"{val[:-3]}e{val[-3:]}",
+        "get_current_trip": lambda val: f"{val[:-3]}e{val[-3:]}",
     }
 
     ERRORS = {
-        '????': 'Syntax error in command',
-        '?WCN': 'Wrong channel number',
-        '?TOT': 'Timeout error (Unit will re-initialise)'
+        "????": "Syntax error in command",
+        "?WCN": "Wrong channel number",
+        "?TOT": "Timeout error (Unit will re-initialise)",
     }
 
     STATUS = {
-        'ON': "Output voltage according to set voltage",
-        'OFF': "Channel front panel switch off",
-        'MAN': "Channel is on, set to manual mode",
-        'ERR': "V_MAX or I_MAX was exceeded",
-        'INH': "Inhibit signal was / is active",
-        'QUA': "Quality of output voltage no guaranteed at present",
-        'L2H': "Output voltage increasing",
-        'H2L': "Output voltage decreasing",
-        'LAS': "Look at status (only after G-command)",
-        'TRP': "Current trip was active"
+        "ON": "Output voltage according to set voltage",
+        "OFF": "Channel front panel switch off",
+        "MAN": "Channel is on, set to manual mode",
+        "ERR": "V_MAX or I_MAX was exceeded",
+        "INH": "Inhibit signal was / is active",
+        "QUA": "Quality of output voltage no guaranteed at present",
+        "L2H": "Output voltage increasing",
+        "H2L": "Output voltage decreasing",
+        "LAS": "Look at status (only after G-command)",
+        "TRP": "Current trip was active",
     }
 
-    @property
-    def identifier(self):
+    def __init__(self, intf, conf):
+        super(IsegHV, self).__init__(intf, conf)
+
+        # Store current channel number; default to channel 1
+        self._channel = None
+
+        # Store number of channels
+        self.n_channel = self._init.get("n_channel", 1)
+        self.channel = self._init.get("channel", 1)
+
+        # Voltage which is considered the high voltage
+        self.high_voltage = self._init.get("high_voltage", None)
+
+        # Software-side voltage limit, set via self.v_lim property
+        self._voltage_limit = self._init.get("v_lim", None)
+
+        if self._voltage_limit is not None:
+            self.voltage_limit = self._init.get("voltage_limit", None)
+
+    def init(self):
+        """Set up the power supply"""
+        # self.write("")  # Synchronize: sometimze needed
+
+        # Important: The manual states that the default answer delay is 3 ms.
+        # When querying the answer_delay property, it returns sometimes 0 although only values in between 1 and 255 ms are valid.
+        # Queries take very long which leads to serial timeouts. I suspect the default value on firmware side is in fact 255 ms (not 3 ms).
+        # Therefore, setting the answer_delay as first thing in the __init__ is sometimes required
+        self.answer_delay = 1  # ms
+
+        # # Add error response for attempting to set voltage too high
+        self.ERRORS[f"? UMAX={self.get_voltage_limit}"] = (
+            "Set voltage exceeds voltage limit"
+        )
+
+    def get_current(self):
         """
-        Read module identifier; return format is "UNIT_NUMBER;SOFTWARE_REL;V_MAX;I_MAX"
+        Actual current flowing at output of self.channel in A
 
         Returns
         -------
-        str
-            Module identifier
+        float
+            Output current in A
         """
-        return self._get_set_property(prop='get_identifier')
+        return float(self._get_set_property(prop="get_current_meas"))
 
-    @property
-    def answer_delay(self):
-        """
-        answer delay (better 'delay') in between two output characters from the power supply in milliseconds.
-        Valid values are 1 up to and including 255 ms
-
-        Returns
-        -------
-        int
-            answer delay in ms (uint8)
-        """
-        return int(self._get_set_property(prop='get_answer_delay'))
-
-    @answer_delay.setter
-    def answer_delay(self, bt):
-        if not 1 <= bt <= 255:
-            raise ValueError("answer delay must be 1 <= answer_delay <= 255 ms")
-        self._get_set_property(prop='set_answer_delay', value=bt)
-
-    @property
-    def voltage(self):
+    def get_voltage(self):
         """
         Actual voltage at self.channel output in V
 
@@ -108,37 +125,47 @@ class IsegHV(HardwareLayer):
         float
             Output voltage in V
         """
-        return float(self._get_set_property(prop='get_voltage_meas'))
+        return float(self._get_set_property(prop="get_voltage_meas"))
 
-    @voltage.setter
-    def voltage(self, voltage):
+    def set_voltage(self, voltage):
         # Check hardware voltage limit
         if abs(voltage) > abs(self.voltage_limit):
-            raise ValueError(f"Voltage of {voltage}V too high! Maximum voltage is {self.voltage_limit} V")
+            raise ValueError(
+                f"Voltage of {voltage}V too high! Maximum voltage is {self.voltage_limit} V"
+            )
 
         # Get module status for checks
-        ms = self.module_status
+        ms = self.get_module_status()
 
         # Issue warning if PSU is in different polarity as value
-        if ms[5] == '1' and voltage < 0:
-            raise ValueError(f"Power supply polarity is set to positive but target voltage of {voltage}V is negative!")
-        elif ms[5] == '0' and voltage > 0:
-            raise ValueError(f"Power supply polarity is set to negative but target voltage of {voltage}V is positive!")
+        if ms[5] == "1" and voltage < 0:
+            raise ValueError(
+                f"Power supply polarity is set to positive but target voltage of {voltage}V is negative!"
+            )
+        elif ms[5] == "0" and voltage > 0:
+            raise ValueError(
+                f"Power supply polarity is set to negative but target voltage of {voltage}V is positive!"
+            )
 
         # Check software voltage limit
-        if self._v_lim is not None:
-            if (ms[5] == '1' and voltage > self._v_lim) or (ms[5] == '0' and voltage < self._v_lim):
-                raise ValueError(f"Voltage of {voltage}V too high! Increase *v_lim={self._v_lim}V* to enable higher voltage!")
+        if self._voltage_limit is not None:
+            if (ms[5] == "1" and voltage > self._voltage_limit) or (
+                ms[5] == "0" and voltage < self._voltage_limit
+            ):
+                raise ValueError(
+                    f"Voltage of {voltage}V too high! Increase *v_lim={self._v_lim}V* to enable higher voltage!"
+                )
 
         # Issue warning if PSU is in manual mode
         # Then voltage can only be changed manually, at the device
-        if ms[6] == '1':
-            logging.warning("Power supply in manual mode; voltage changes have no effect!")
+        if ms[6] == "1":
+            logging.warning(
+                "Power supply in manual mode; voltage changes have no effect!"
+            )
 
-        self._get_set_property(prop='set_voltage', value=abs(voltage))
+        self._get_set_property(prop="set_voltage", value=abs(voltage))
 
-    @property
-    def voltage_target(self):
+    def get_source_voltage(self):
         """
         Target voltage of self.channel output in V
         This is the voltage which is set using self.voltage property
@@ -148,38 +175,9 @@ class IsegHV(HardwareLayer):
         float
             Target voltage in V
         """
-        return float(self._get_set_property(prop='get_voltage_set'))
+        return float(self._get_set_property(prop="get_source_voltage"))
 
-    @property
-    def current(self):
-        """
-        Actual current flowing at output of self.channel in A
-
-        Returns
-        -------
-        float
-            Output current in A
-        """
-        return float(self._get_set_property(prop='get_current_meas'))
-
-    @property
-    def v_lim(self):
-        """
-        Software-side voltage limit, initially None. If set, a check will happen before each voltage change
-
-        Returns
-        -------
-        float, None
-            Software-side voltage limit
-        """
-        return self._v_lim
-
-    @v_lim.setter
-    def v_lim(self, voltage_limit):
-        self._v_lim = voltage_limit if voltage_limit is None else float(voltage_limit)
-
-    @property
-    def voltage_limit(self):
+    def get_hardware_voltage_limit(self):
         """
         Return current hardware-side voltage limit of self.channel in V
 
@@ -189,10 +187,29 @@ class IsegHV(HardwareLayer):
             Voltage limit in V
         """
         # Property get_v_lim returns voltage limit as percentage of max voltage
-        return int(self._get_set_property(prop='get_v_lim')) / 100.0 * float(self.V_MAX[:-1])
+        return (
+            int(self._get_set_property(prop="get_voltage_limit"))
+            / 100.0
+            * float(self.V_MAX[:-1])
+        )
 
-    @property
-    def current_limit(self):
+    def get_voltage_limit(self):
+        """
+        Software-side voltage limit, initially None. If set, a check will happen before each voltage change
+
+        Returns
+        -------
+        float, None
+            Software-side voltage limit
+        """
+        return self._voltage_limit
+
+    def set_voltage_limit(self, voltage_limit):
+        self._voltage_limit = (
+            voltage_limit if voltage_limit is None else float(voltage_limit)
+        )
+
+    def get_current_limit(self):
         """
         Return current limit of self.channel in A
 
@@ -202,10 +219,57 @@ class IsegHV(HardwareLayer):
             Current limit in A
         """
         # Property get_i_lim returns voltage limit as percentage of max current
-        return int(self._get_set_property(prop='get_i_lim')) / 100.0 * float(self.I_MAX[:-2])
+        return (
+            int(self._get_set_property(prop="get_current_limit")) / 100.0 * float(self.I_MAX[:-2])
+        )
 
-    @property
-    def ramp_speed(self):
+    def set_current_trip(self, resolution="mA"):
+        """
+        Read current trip/limit, if 0 -> no trip
+
+        Returns
+        -------
+        float
+            Current trip
+        """
+        if resolution == "muA":
+            return float(self._get_set_property(prop="get_current_trip_muA"))
+        else:
+            return float(self._get_set_property(prop="get_current_trip_mA"))
+
+    def set_current_trip(self, ct, resolution="mA"):
+        if resolution == "muA":
+            self._get_set_property(prop="set_current_trip_muA", value=ct)
+        else:
+            self._get_set_property(prop="set_current_trip_mA", value=ct)
+
+    def start_voltage_ramp(self):
+        """
+        Manually initiate the change of the voltage.
+        Only needed if self.autostart is False
+        """
+        self._get_set_property(prop="start_voltage_ramp")
+
+    def get_current_channel(self):
+        return self._channel
+
+    def set_current_channel(self, ch):
+        if not 1 <= ch <= self.n_channel:
+            raise ValueError(f"Channel number must be 1 <= channel <= {self.n_channel}")
+        self._channel = ch
+
+    def get_identifier(self):
+        """
+        Read module identifier; return format is "UNIT_NUMBER;SOFTWARE_REL;V_MAX;I_MAX"
+
+        Returns
+        -------
+        str
+            Module identifier
+        """
+        return self._get_set_property(prop="get_identifier")
+
+    def get_ramp_speed(self):
         """
         Read the output voltage ramping speed in V/s.
         Valid values are 1 up to and including 255 V/s
@@ -215,32 +279,51 @@ class IsegHV(HardwareLayer):
         int
             Ramp speed of output voltage
         """
-        return int(self._get_set_property(prop='get_ramp_speed'))
+        return int(self._get_set_property(prop="get_ramp_speed"))
 
-    @ramp_speed.setter
-    def ramp_speed(self, rs):
+    def set_ramp_speed(self, rs):
         if not 1 <= rs <= 255:
             raise ValueError("Ramp speed must be 1 <= ramp_speed <= 255 V/s")
-        self._get_set_property(prop='set_ramp_speed', value=rs)
+        self._get_set_property(prop="set_ramp_speed", value=rs)
 
-    @property
-    def current_trip(self):
+    def get_answer_delay(self):
         """
-        Read current trip, if 0 -> no trip
+        answer delay (better 'delay') in between two output characters from the power supply in milliseconds.
+        Valid values are 1 up to and including 255 ms
 
         Returns
         -------
-        float
-            Current trip
+        int
+            answer delay in ms (uint8)
         """
-        return float(self._get_set_property(prop='get_current_trip'))
+        return int(self._get_set_property(prop="get_answer_delay"))
 
-    @current_trip.setter
-    def current_trip(self, ct):
-        self._get_set_property(prop='set_current_trip', value=ct)
+    def set_answer_delay(self, bt):
+        if not 1 <= bt <= 255:
+            raise ValueError("answer delay must be 1 <= answer_delay <= 255 ms")
+        self._get_set_property(prop="set_answer_delay", value=bt)
 
-    @property
-    def status_word(self):
+    def get_autostart(self):
+        """
+        Whether output voltage changes automatically after setting value via self.voltage property.
+        Alternatively, call self.start_voltage_ramp method to initaite voltagte change manually.
+        self._get_set_property(prop='get_autostart') -> 008: autostart is active
+        self._get_set_property(prop='get_autostart') -> 000: autostart is inactive
+
+        Returns
+        -------
+        bool
+            Wheter autostart is active
+        """
+        return self._get_set_property(prop="get_autostart") == "008"
+
+    def set_autostart(self, state):
+        self._get_set_property(prop="set_autostart", value=8 if state else 0)
+
+    def get_polarity(self):
+        return 1 if self.module_status[5] == "1" else -1
+
+    def get_status_word(self):
         """
         Read status word of self.channel
         See self.STATUS and self.status_description
@@ -250,10 +333,9 @@ class IsegHV(HardwareLayer):
         str
             Status word
         """
-        return self._get_set_property(prop='get_status_word')
+        return self._get_set_property(prop="get_status_word")
 
-    @property
-    def status_description(self):
+    def get_status_description(self):
         """
         Read description corresponding to self.status_word
 
@@ -266,10 +348,9 @@ class IsegHV(HardwareLayer):
         for status in self.STATUS:
             if status in status_word:
                 return f"{status_word}: {self.STATUS[status]}"
-        return 'No description'
+        return "No description"
 
-    @property
-    def module_status(self):
+    def get_module_status(self):
         """
         Read module status of self.channel
         Return value is uint8, use '{:08b}'.format(value) to get bits
@@ -279,10 +360,9 @@ class IsegHV(HardwareLayer):
         int
             Value of status
         """
-        return '{:08b}'.format(int(self._get_set_property(prop='get_module_status')))
+        return "{:08b}".format(int(self._get_set_property(prop="get_module_status")))
 
-    @property
-    def module_description(self):
+    def get_module_description(self):
         """
         Read module status and print out desciptive string from it
 
@@ -291,107 +371,37 @@ class IsegHV(HardwareLayer):
         str
             Module description string
         """
-        def module_msg(bit, prefix, t_msg, f_msg=''):
-            return f'{prefix} ' + (t_msg if bit == '1' else f_msg) + '\n'
+
+        def module_msg(bit, prefix, t_msg, f_msg=""):
+            return f"{prefix} " + (t_msg if bit == "1" else f_msg) + "\n"
 
         _description = {
-            0: dict(prefix='', t_msg="Quality of output voltage not given at present"),
-            1: dict(prefix='', t_msg="V_MAX or I_MAX is / was exceeded"),
-            2: dict(prefix='INHIBIT signal', t_msg="is / was active", f_msg="inactive"),
+            0: dict(prefix="", t_msg="Quality of output voltage not given at present"),
+            1: dict(prefix="", t_msg="V_MAX or I_MAX is / was exceeded"),
+            2: dict(prefix="INHIBIT signal", t_msg="is / was active", f_msg="inactive"),
             3: dict(prefix="KILL_ENABLE is", t_msg="on", f_msg="off"),
             4: dict(prefix="Front-panel HV-ON switch is", t_msg="OFF", f_msg="ON"),
             5: dict(prefix="Polarity set to", t_msg="positive", f_msg="negative"),
             6: dict(prefix="Control via", t_msg="manual", f_msg="RS-232 interface"),
-            7: dict(prefix="Display dialled to", t_msg="voltage measurement", f_msg="current measurement")
+            7: dict(
+                prefix="Display dialled to",
+                t_msg="voltage measurement",
+                f_msg="current measurement",
+            ),
         }
 
-        module_description = ''
+        module_description = ""
         for i, bit in enumerate(self.module_status):
             module_description += module_msg(bit=bit, **_description[i])
         return module_description
 
-    @property
-    def autostart(self):
-        """
-        Whether output voltage changes automatically after setting value via self.voltage property.
-        Alternatively, call self.start_voltage_ramp method to initaite voltagte change manually.
-        self._get_set_property(prop='get_autostart') -> 008: autostart is active
-        self._get_set_property(prop='get_autostart') -> 000: autostart is inactive
-
-        Returns
-        -------
-        bool
-            Wheter autostart is active
-        """
-        return self._get_set_property(prop='get_autostart') == '008'
-
-    @autostart.setter
-    def autostart(self, state):
-        self._get_set_property(prop='set_autostart', value=8 if state else 0)
-
-    @property
-    def channel(self):
-        return self._channel
-
-    @property
-    def polarity(self):
-        return 1 if self.module_status[5] == '1' else -1
-
-    @channel.setter
-    def channel(self, ch):
-        if not 1 <= ch <= self.n_channel:
-            raise ValueError(f"Channel number must be 1 <= channel <= {self.n_channel}")
-        self._channel = ch
-
-    @property
-    def UNIT_NUMBER(self):
-        return self.identifier.split(';')[0]
-
-    @property
-    def SOFTWARE_REL(self):
-        return self.identifier.split(';')[1]
-
-    @property
-    def V_MAX(self):
-        return self.identifier.split(';')[2]
-
-    @property
-    def I_MAX(self):
-        return self.identifier.split(';')[3]
-
-    def __init__(self, intf, conf):
-        super(IsegHV, self).__init__(intf, conf)
-
-        # Store current channel number; default to channel 1
-        self._channel = None
-        # Store number of channels
-        self.n_channel = self._init.get('n_channel', 1)
-        self.channel = self._init.get('channel', 1)
-        # Voltage which is considered the high voltage
-        self.high_voltage = self._init.get('high_voltage', None)
-        # Software-side voltage limit, set via self.v_lim property
-        self._v_lim = self._init.get('v_lim', None)
-
-    def setup_ps(self):
-        """Set up the power supply"""
-        # self.write("")  # Synchronize: sometimze needed
-
-        # Important: The manual states that the default answer delay is 3 ms.
-        # When querying the answer_delay property, it returns sometimes 0 although only values in between 1 and 255 ms are valid.
-        # Queries take very long which leads to serial timeouts. I suspect the default value on firmware side is in fact 255 ms (not 3 ms).
-        # Therefore, setting the answer_delay as first thing in the __init__ is sometimes required
-        self.answer_delay = 1  # ms
-
-        # Add error response for attempting to set voltage too high
-        self.ERRORS[f'? UMAX={self.voltage_limit}'] = "Set voltage exceeds voltage limit"
-
     def _get_set_property(self, prop, value=None):
 
-        if '{channel}' in self.CMDS[prop] and '{value}' in self.CMDS[prop]:
+        if "{channel}" in self.CMDS[prop] and "{value}" in self.CMDS[prop]:
             cmd = self.CMDS[prop].format(channel=self.channel, value=value)
-        elif '{channel}' in self.CMDS[prop]:
+        elif "{channel}" in self.CMDS[prop]:
             cmd = self.CMDS[prop].format(channel=self.channel)
-        elif '{value}' in self.CMDS[prop]:
+        elif "{value}" in self.CMDS[prop]:
             cmd = self.CMDS[prop].format(value=value)
         else:
             cmd = self.CMDS[prop]
@@ -446,22 +456,211 @@ class IsegHV(HardwareLayer):
         # RECV -> actual data        // recv the actual data
         echo = str(self._intf.query(msg)).strip()
         if echo != msg:
-            raise RuntimeError(f"Issued command ({msg}) and echoed command ({echo}) differ.")
+            raise RuntimeError(
+                f"Issued command ({msg}) and echoed command ({echo}) differ."
+            )
         return self.read()
 
-    def start_voltage_ramp(self):
-        """
-        Manually initiate the change of the voltage.
-        Only needed if self.autostart is False
-        """
-        self._get_set_property(prop='start_voltage_ramp')
-
-    def hv_on(self):
+    def on(self):
         try:
-            _ = float(self.high_voltage)
-            self.voltage = self.high_voltage
+            self.voltage = float(self.high_voltage)
         except TypeError:
-            raise ValueError("High voltage is not set. Set *high_voltage* attribute to numerical value")
+            raise ValueError(
+                "High voltage is not set. Set *high_voltage* attribute to numerical value"
+            )
 
+    def off(self):
+        self.set_voltage(0)
+
+    def get_on(self):
+        return "0" if self.get_module_status()[4] == "1" else "1"
+
+    def set_voltage_range(self): ...  # Not implemented
+
+    def set_current(self): ...  # Not implemented
+
+    def source_current(self): ...  # Not implemented
+
+    def soruce_volt(self): ...  # Not implemented
+
+    @property
+    def UNIT_NUMBER(self):
+        return self.identifier().split(";")[0]
+
+    @property
+    def SOFTWARE_REL(self):
+        return self.identifier().split(";")[1]
+
+    @property
+    def V_MAX(self):
+        return self.identifier().split(";")[2]
+
+    @property
+    def I_MAX(self):
+        return self.identifier().split(";")[3]
+
+    ##### BEWLOW DEPRECATED #####
+
+    @property
+    def hv_on(self):
+        """
+        Use 'on' method instead
+        """
+        self.on()
+
+    @property
     def hv_off(self):
-        self.voltage = 0
+        """
+        Use 'off' method instead
+        """
+        self.off()
+
+    @property
+    def polarity(self):
+        """
+        Use 'get_polarity' method instead
+        """
+        return self.get_polarity()
+
+    @property
+    def autostart(self):
+        """
+        Use 'get_autostart' method instead
+        """
+        return self.get_autostart()
+
+    @autostart.setter
+    def autostart(self, state):
+        """
+        Use 'set_autostart' method instead
+        """
+        self.set_autostart(state)
+
+    @property
+    def answer_delay(self):
+        """
+        Use 'get_answer_delay' method instead
+        """
+        return self.get_answer_delay()
+
+    @answer_delay.setter
+    def answer_delay(self, bt):
+        """
+        Use 'set_answer_delay' method instead
+        """
+        self.set_answer_delay(bt)
+
+    @property
+    def ramp_speed(self):
+        """
+        Use 'get_ramp_speed' method instead
+        """
+        return self.get_ramp_speed()
+
+    @ramp_speed.setter
+    def ramp_speed(self, rs):
+        """
+        Use 'set_ramp_speed' method instead
+        """
+        self.set_ramp_speed(rs)
+
+    @property
+    def channel(self):
+        """
+        Use 'get_current_channel' method instead
+        """
+        return self.get_current_channel()
+
+    @channel.setter
+    def channel(self, ch):
+        """
+        Use 'set_current_channel' method instead
+        """
+        self.set_current_channel(ch)
+
+    @property
+    def current_trip(self):
+        """
+        Use 'get_current_trip' method instead.
+        This property will use the mA resolution!
+        """
+        return self.get_current_trip()
+
+    @current_trip.setter
+    def current_trip(self, ct):
+        """
+        Use 'set_current_trip' method instead
+        This setter will use the mA resolution!
+        """
+        self.set_current_trip(ct)
+
+    @property
+    def voltage(self):
+        """
+        Use 'get_voltage' method instead
+        """
+        return self.get_voltage()
+
+    @property
+    def current(self):
+        """
+        Use 'get_current' method instead
+        """
+        return self.get_current()
+
+    @property
+    def voltage_target(self):
+        """
+        Use 'get_source_voltage' method instead
+        """
+        return self.get_source_voltage()
+
+    @property
+    def v_lim(self):
+        return self.get_voltage_limit()
+
+    @v_lim.setter
+    def v_lim(self, voltage_limit):
+        self.set_voltage_limit(voltage_limit)
+
+    @property
+    def voltage_limit(self):
+        """
+        Use 'get_hardware_voltage_limit' method instead
+        """
+        return self.get_hardware_voltage_limit()
+
+    @property
+    def identifier(self):
+        """
+        Use 'get_identifier' method instead
+        """
+        return self.get_identifier()
+
+    @property
+    def status_word(self):
+        """
+        Use 'get_status_word' method instead
+        """
+        return self.get_status_word()
+
+    @property
+    def module_status(self):
+        """
+        Use 'get_module_status' method instead
+        """
+        return self.get_module_status()
+
+    @property
+    def module_description(self):
+        """
+        Use 'get_module_description' method instead
+        """
+        return self.get_module_description()
+
+    @property
+    def status_description(self):
+        """
+        Use 'get_status_description' method instead
+        """
+        return self.get_status_description()

--- a/examples/lab_devices/iseg_shq.py
+++ b/examples/lab_devices/iseg_shq.py
@@ -14,35 +14,53 @@ dut = Dut('iseg_shq.yaml')
 dut.init()
 
 # Set PSU channel
-dut['SHQ'].channel = 1
+dut['SHQ'].set_current_channel(1)
 
 # Set voltage ramp speed in V/s
-dut['SHQ'].ramp_speed = 2
+dut['SHQ'].set_ramp_speed(2)
 
 # Set autostart to True in order to automatically start voltage change when new voltage is set
-dut['SHQ'].autostart = True
+dut['SHQ'].set_autostart(True)
 
 # Set voltage to +-30 volts; requires hardware polarity change
-polarity = dut['SHQ'].polarity
+polarity = dut['SHQ'].get_polarity()
 
-dut['SHQ'].high_voltage = 15 * polarity  # Set high voltage; hv_on() / hv_off()
-dut['SHQ'].v_lim = 20 * polarity  # Set software-side voltage limit
-dut['SHQ'].voltage = 10 * polarity  # Set voltage
+dut['SHQ'].set_high_voltage(15 * polarity)  # Set high voltage; hv_on() / hv_off()
+dut['SHQ'].set_voltage_limit(20 * polarity)  # Set software-side voltage limit
+dut['SHQ'].set_voltage(10 * polarity)  # Set voltage
+
+dut['SHQ'].set_current_trip(10)  # Set current trip in mA
+dut['SHQ'].set_current_trip(10000, resolution="muA")  # Set current trip in µA
 
 # Disable autostart
-dut['SHQ'].autostart = False
+dut['SHQ'].set_autostart(False)
 
 # Read back the voltage that is measured at the output
-print(dut['SHQ'].voltage)
+print(dut['SHQ'].get_voltage())
+
+# Read back the current that is measured at the output
+print(dut['SHQ'].get_current())
 
 # Read back the software-side voltage limit
-print(dut['SHQ'].v_lim)
+print(dut['SHQ'].get_voltage_limit())
+
+# Read back the hardware-side voltage-limit
+print(dut['SHQ'].get_hardware_voltage_limit())
 
 # Read back the voltage that is set to be the output
-print(dut['SHQ'].voltage_target)
+print(dut['SHQ'].get_source_voltage())
+
+# Read back the current trip (default is mA range)
+print(dut['SHQ'].get_current_trip())
+
+# Read back the current trip in mA
+print(dut['SHQ'].get_current_trip(resolution="mA"))
+
+# Read back the current trip in µA
+print(dut['SHQ'].get_current_trip("muA"))
 
 # Print the module description
-print(dut['SHQ'].module_description)
+print(dut['SHQ'].get_module_description())
 
 # Print the module description
-print(dut['SHQ'].identifier)
+print(dut['SHQ'].get_identifier())

--- a/examples/lab_devices/iseg_shq.yaml
+++ b/examples/lab_devices/iseg_shq.yaml
@@ -17,3 +17,4 @@ hw_drivers:
         # v_lim : 100 # Set software-side voltage limit to be 100 V
         n_channel : 1 # Set number of channels the ISEG HV PS has 
         channel : 1  # Set channel number
+        autostart : True # Set autostart to True in order to automatically start voltage change when new voltage is set


### PR DESCRIPTION
- Added get_* and set_* methods for compatibility reasons.
- Deprecated decorated getter/setter properties, but they are still available for backward compatibility.
- Refactored code by replacing setup_ps() with init().
- Added get_current_trip* commands for different Ampere ranges (default Ampere range is now mA).