### PR TITLE
Fix bitarray.endian()

### DIFF
--- a/basil/utils/BitLogic.py
+++ b/basil/utils/BitLogic.py
@@ -66,7 +66,7 @@ class BitLogic(bitarray):
         return struct.unpack_from(fmt, ba.tobytes())[0]
 
     def __str__(self):
-        if self.endian() == 'little':
+        if self.endian == 'little':
             return self.to01()[::-1]
         else:
             return self.to01()

--- a/basil/utils/utils.py
+++ b/basil/utils/utils.py
@@ -39,7 +39,7 @@ def bitvector_to_byte_array(bitvector):
 
 
 def bitarray_to_byte_array(bitarr):
-    ba = bitarray(bitarr, endian=bitarr.endian())
+    ba = bitarray(bitarr, endian=bitarr.endian)
     ba.reverse()  # this flip the byte order and the bit order of each byte
     bs = np.frombuffer(ba.tobytes(), dtype=np.uint8)  # byte padding happens here, bitarray.tobytes()
     bs = (bs * np.uint64(0x0202020202) & 0x010884422010) % 1023

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 numpy
 pyyaml
-bitarray>=2.0.0
+bitarray>=3.4.0
 GitPython
 six
 ruamel.yaml 


### PR DESCRIPTION
Fixes #240 by adopting the API change in bitarray and bumping the minimum required version accordingly.