### PR TITLE
Fix pointer size for BRAM FIFO

### DIFF
--- a/basil/firmware/modules/bram_fifo/bram_fifo_core.v
+++ b/basil/firmware/modules/bram_fifo/bram_fifo_core.v
@@ -115,8 +115,7 @@ wire FULL_BUF;
 
 assign FIFO_READ_NEXT_OUT = !FULL_BUF;
 
-`include "../includes/log2func.v"
-localparam POINTER_SIZE = `CLOG2(DEPTH);
+localparam POINTER_SIZE = 32;
 
 generic_fifo #(
     .DATA_SIZE(32),
@@ -132,7 +131,6 @@ generic_fifo #(
     .data_out(FIFO_DATA_BUF[31:0]),
     .size(CONF_SIZE[POINTER_SIZE-1:0])
 );
-assign CONF_SIZE[31:POINTER_SIZE] = 0;
 
 always @(posedge BUS_CLK)
     BUS_DATA_OUT_DATA <= FIFO_DATA_BUF;

--- a/basil/firmware/modules/utils/generic_fifo.v
+++ b/basil/firmware/modules/utils/generic_fifo.v
@@ -33,7 +33,7 @@ output reg [DATA_SIZE-1:0] data_out;
 
 reg [DATA_SIZE:0] mem [DEPTH-1:0];
 
-localparam POINTER_SIZE = 16;
+localparam POINTER_SIZE = 32;
 
 reg [POINTER_SIZE-1:0] rd_pointer, rd_tmp, wr_pointer;
 output reg [POINTER_SIZE-1:0] size;


### PR DESCRIPTION
The default `DEPTH` parameter for the BRAM FIFO requires more than 16-bit pointer size. Instead of 16, I hardcoded this to 32 now (see also #247) which should be plenty enough.