### PR TITLE
Reduce number of bits for address pointer

### DIFF
--- a/basil/firmware/modules/utils/generic_fifo.v
+++ b/basil/firmware/modules/utils/generic_fifo.v
@@ -33,7 +33,7 @@ output reg [DATA_SIZE-1:0] data_out;
 
 reg [DATA_SIZE:0] mem [DEPTH-1:0];
 
-localparam POINTER_SIZE = 32;
+localparam POINTER_SIZE = 16;
 
 reg [POINTER_SIZE-1:0] rd_pointer, rd_tmp, wr_pointer;
 output reg [POINTER_SIZE-1:0] size;


### PR DESCRIPTION
In Vivado 2025.2, I am still getting errors regarding the pointer size. When inferring BRAM, the instantiated RAMB36E1 block has a maximum address size of 16bit, so I adjusted it in the `generic_fifo` accordingly.
While it should not matter for distributed RAM, the address space is still large enough for any reasonable use case at the moment, I think.