### PR TITLE
Added optional HW dependencies

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,6 +33,9 @@ dependencies = [
 "Documentation" = "https://basil.readthedocs.io/en/latest/"
 "Repository" = "https://github.com/SiLab-Bonn/basil/"
 
+[project.optional-dependencies]
+hw = ["pyserial", "PyVISA"]
+
 [tool.setuptools]
 include-package-data = true
 


### PR DESCRIPTION
Added the possibility to install the optional packages `pyserial` and `pyvista`.
In response to #188. 