### PR TITLE
Unify usage of POINTER_SIZE across modules

### DIFF
--- a/basil/firmware/modules/bram_fifo/bram_fifo_core.v
+++ b/basil/firmware/modules/bram_fifo/bram_fifo_core.v
@@ -72,6 +72,8 @@ begin
     end
 end
 
+localparam POINTER_SIZE = 32;
+
 // read reg
 wire [31:0] CONF_SIZE_BYTE; // write data count, 1 - 2 - 3, in units of byte
 reg [31:0] CONF_SIZE_BYTE_BUF;
@@ -104,8 +106,10 @@ end
 
 always @(posedge BUS_CLK)
 begin
-    if (BUS_ADD == 4 && BUS_RD)
-        CONF_SIZE_BYTE_BUF <= CONF_SIZE_BYTE;
+    if (BUS_ADD == 4 && BUS_RD) begin
+        // Pad upper bits with 0s if pointer size less than 32
+        CONF_SIZE_BYTE_BUF <= {{(32-POINTER_SIZE){1'b0}}, CONF_SIZE_BYTE[POINTER_SIZE-1:0]};
+    end
 end
 
 //reg                   FIFO_READ_NEXT_OUT_BUF;
@@ -115,11 +119,10 @@ wire FULL_BUF;
 
 assign FIFO_READ_NEXT_OUT = !FULL_BUF;
 
-localparam POINTER_SIZE = 32;
-
 generic_fifo #(
     .DATA_SIZE(32),
-    .DEPTH(DEPTH)
+    .DEPTH(DEPTH),
+    .POINTER_SIZE(POINTER_SIZE)
 ) i_buf_fifo (
     .clk(BUS_CLK),
     .reset(RST),

--- a/basil/firmware/modules/utils/generic_fifo.v
+++ b/basil/firmware/modules/utils/generic_fifo.v
@@ -10,7 +10,8 @@
 
 module generic_fifo #(
     parameter DATA_SIZE = 32,
-    parameter DEPTH = 8
+    parameter DEPTH = 8,
+    parameter POINTER_SIZE = 16 // maximum in Xilinx 7-series
 )(   
     clk,
     reset,
@@ -32,8 +33,6 @@ output reg empty;
 output reg [DATA_SIZE-1:0] data_out;
 
 reg [DATA_SIZE:0] mem [DEPTH-1:0];
-
-localparam POINTER_SIZE = 16;
 
 reg [POINTER_SIZE-1:0] rd_pointer, rd_tmp, wr_pointer;
 output reg [POINTER_SIZE-1:0] size;


### PR DESCRIPTION
Closes #264, more explanation can be found there. In general, this allows synthesis for 7-series devices (with 16-bit address BRAM https://docs.amd.com/r/en-US/ug953-vivado-7series-libraries/RAMB36E1) and usage of the `bram_fifo` module, e.g. for simulations, where data is read via the basil bus.