### PR TITLE
Stretch TDC input signal

### DIFF
--- a/basil/firmware/modules/tdl_tdc/controller.v
+++ b/basil/firmware/modules/tdl_tdc/controller.v
@@ -24,7 +24,6 @@ module controller #(
 	output reg [mux_bits-1:0] mux_addr
 );
 
-
 // 2 bit flag to store hit and miss information of the group of
 // samples. This needs to be in sync with the sample deser
 localparam TDL_IDLE = 0;
@@ -38,12 +37,6 @@ localparam SIG_IN = 1;
 localparam SIG_IN_B = 2;
 localparam CALIB_OSC = 3;
 
-// function [state_bits-1:0] int_to_gray;
-// 	input [state_bits-1:0] int;
-// 	begin
-// 		int_to_gray = int ^ (int >> 1);
-// 	end
-// endfunction
 // TDC states
 // These need to be in sync with the word broker.
 localparam [state_bits-1:0] IDLE = 0;
@@ -69,9 +62,6 @@ wire hit;
 // sampling. Only if a hit was detected and on the next cycle the input is
 // still a solid 1 do we count a hit.
 assign hit = (hit_status == TDL_HIT) && tdl_status;
-
-
-
 
 always @(state, en_write_trigger_distance) begin
 	// State dependent control outputs

--- a/basil/firmware/modules/tdl_tdc/sw_interface.v
+++ b/basil/firmware/modules/tdl_tdc/sw_interface.v
@@ -213,7 +213,7 @@ graycode_2stage_cdc #(.DATA_WIDTH(32)) event_count_cdc (
 	.data_out_clk(event_cnt)
 );
 
-// This is a strange additional buffer from the original tdc_s3 (L:420).
+// Buffer upper bits of counter to preserve while reading in blocks of 1 byte (width of bus data)
 always @(posedge BUS_CLK) begin
 	event_cnt_buf <= event_cnt;
 	if (ip_add == 2 && ip_rd)

--- a/basil/firmware/modules/tdl_tdc/tdl_tdc.v
+++ b/basil/firmware/modules/tdl_tdc/tdl_tdc.v
@@ -118,7 +118,7 @@ always @(posedge CLK160) begin
 		fifo_over_cnt <= fifo_over_cnt;
 end
 
-gerneric_fifo #(
+generic_fifo #(
 	.DATA_SIZE(32),
 	.DEPTH(512)
 ) fifo_i (

--- a/basil/firmware/modules/tdl_tdc/tdl_tdc_core.v
+++ b/basil/firmware/modules/tdl_tdc/tdl_tdc_core.v
@@ -38,8 +38,6 @@ module tdc_core #(
 	output wire [31:0] event_cnt
 );
 
-
-
 localparam dlyline_bits = 96; // TODO: should this be a localparam?
 localparam clk_ratio = 3;
 // The following numbers of bits should add up to 33, as the bus is 32 bit and
@@ -50,9 +48,7 @@ localparam fine_time_bits = 2; // We need that clk_ratio <= 2^fine_time_bits
 localparam state_bits = 4;
 localparam word_type_bits = 3; // TODO: this isn't yet parametric
 
-
-
-// corse counter.
+// Coarse counter
 wire [corsebits-1:0] corse_count;
 wire counter_count, counter_reset;
 // TODO: should clip_reset be set?
@@ -81,6 +77,26 @@ clock_divider #(.DIVISOR(14)) calib_sig_gen (
 	.CLOCK(sig_calib)
 );
 
+// Stretch trig_in to make sure we do not miss very short pulses (such as scintillator)
+reg [1:0] cnt;
+reg trig_in_delayed;
+always @(posedge trig_in or posedge CLK or posedge rst) begin
+	if (rst) begin
+		trig_in_delayed <= 0;
+		cnt <= 0;
+	end
+	else if (trig_in) begin // asynchronous trigger in
+		trig_in_delayed <= 1'b1;
+		cnt             <= 2'd2;
+	end
+	else begin // synchronous trigger out
+		if (cnt != 0)
+			cnt <= cnt - 1;
+		
+		if (cnt == 1)
+			trig_in_delayed <= 0;
+	end
+end
 
 // Input mux addresses for more verbose code
 // For 4 inputs, 2 bits are sufficient
@@ -103,7 +119,7 @@ always @ (posedge CLK)
 	input_mux_addr_buf <= input_mux_addr;
 always @(*) begin
 	case(input_mux_addr_buf)
-		TRIG_IN: tdl_input <= trig_in;
+		TRIG_IN: tdl_input <= trig_in_delayed;
 		SIG_IN: tdl_input <= sig_in;
 		SIG_IN_B: tdl_input <= ~sig_in;
 		CALIB_OSC: tdl_input <= sig_calib;

--- a/basil/firmware/modules/tdl_tdc/tdl_tdc_core.v
+++ b/basil/firmware/modules/tdl_tdc/tdl_tdc_core.v
@@ -92,7 +92,7 @@ always @(posedge trig_in or posedge CLK or posedge rst) begin
 	else begin // synchronous trigger out
 		if (cnt != 0)
 			cnt <= cnt - 1;
-		
+
 		if (cnt == 1)
 			trig_in_delayed <= 0;
 	end


### PR DESCRIPTION
The TDC requires an input signal (both trigger and pulse) that is more than one clock cycle ( > 6.25 ns) long. For very short trigger pulses (e.g. scintillators), hits can be lost. This PR stretches the trigger signal to (trigger signal + 2 * 6.25 ns) which significantly increases the number of recorded triggers.