### PR TITLE
Fix redundant dependencies that might break builds

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,10 +27,6 @@ dependencies = [
     "GitPython",
     "six",
     "ruamel.yaml",
-    "cocotb>=2.0.1",
-    "cocotb-bus>=0.3.0",
-    "pytest>=9.0.3",
-    "cocotb-test>=0.2.6",
 ]
 
 [project.urls]


### PR DESCRIPTION
#272 introduced duplicate dependencies in the `pyproject.toml`, that should be optional ones in any case. This might break builds, if the environment is not set up and targeting any cocotb business. @kcaisley 