### PR TITLE
Fix spi bram

### DIFF
--- a/basil/firmware/modules/spi/blk_mem_gen_8_to_1_2k.v
+++ b/basil/firmware/modules/spi/blk_mem_gen_8_to_1_2k.v
@@ -4,19 +4,27 @@
  * SiLab, Institute of Physics, University of Bonn
  * ------------------------------------------------------------
  *
- * Asymmetric true dual-port BRAM: 2048 x 8-bit (Port A) / 16384 x 1-bit (Port B).
- * Total capacity: 16,384 bits → inferred as RAMB18E1 on 7-series (Kintex-7).
+ * Asymmetric dual-port memory: 2048 x 8-bit (Port A) / 16384 x 1-bit (Port B).
+ * Total capacity: 16,384 bits → intended to infer one 7-series RAMB18E1 in
+ * block-RAM memory mode. See AMD/Xilinx UG473, 7 Series FPGAs Memory Resources:
+ * https://docs.amd.com/v/u/en-US/ug473_7Series_Memory_Resources
  *
  * Replaces the legacy RAMB16_S1_S9 primitive (Spartan-3/Virtex-4 era),
  * which is unsupported in Vivado.
  *
  * Inference strategy:
- *   Underlying array is 16384 × 1-bit. Port B (1-bit) accesses it directly.
- *   Port A (8-bit) uses a single always block with a procedural for loop
- *   that expands to 8 consecutive 1-bit locations at {ADDRA, i[2:0]}.
- *   Vivado sees only two clocked ports and infers a single RAMB18E1 in
- *   true dual-port (TDP) mode with asymmetric widths.
+ *   Underlying array is 2048 × 8-bit. Port A accesses full bytes directly.
+ *   Port B maps its 14-bit bit address to byte address ADDRB[13:3] and bit
+ *   index ADDRB[2:0]. This keeps the memory declaration in a conventional
+ *   byte-wide shape for Vivado inference while preserving the legacy 8-to-1
+ *   asymmetric interface.
  *   (* ram_style = "block" *) attribute forces BRAM over distributed RAM.
+ *
+ * This is deliberately not the dedicated BRAM FIFO mode described in UG473.
+ * Although the SPI data path is FIFO-like (bytes are played out serially),
+ * spi_core owns the byte/bit addresses, repeat count, waits, and replay control.
+ * A BRAM FIFO primitive would hide/destructively advance those pointers, while
+ * this block must remain an addressable, replayable SPI pattern/readback memory.
  *
  * Port mapping (unchanged from original):
  *   Port A: 8-bit wide, 2048 deep  — ADDRA[10:0], DINA[7:0], DOUTA[7:0], WEA
@@ -28,7 +36,7 @@
 `ifndef BLK_MEM_GEN_8_TO_1_2K
 `define BLK_MEM_GEN_8_TO_1_2K
 
-`timescale 1ps/1ps
+`timescale 1ns/1ps
 `default_nettype none
 
 
@@ -53,53 +61,50 @@ input  wire [7 : 0] DINA;
 input  wire [0 : 0] DINB;
 
 // -------------------------------------------------------------------
-// Underlying array: 16384 × 1-bit, total 16,384 bits.
-// Vivado infers a single RAMB18E1 in true-dual-port mode with
-// asymmetric widths (Port A = 8-bit, Port B = 1-bit).
+// Underlying array: 2048 × 8-bit = 16,384 bits.
+// Port B's 14-bit address is split into byte address and bit index.
 // -------------------------------------------------------------------
 
+// The generic module supports two writable ports for legacy compatibility, but
+// current SPI instances enable only one write port per memory. Verilator cannot
+// prove that for the default parameterization and reports MULTIDRIVEN.
+// verilator lint_off MULTIDRIVEN
 (* ram_style = "block" *)
-reg [0:0] ram [0:16383];
+reg [7:0] ram [0:2047];
+// verilator lint_on MULTIDRIVEN
+
+wire [10:0] addrb_word = ADDRB[13:3];
+wire [2:0] addrb_bit = ADDRB[2:0];
 
 // ------------------------------
-// Port A — 8-bit synchronous (procedural for loop, one port)
-//
-// ADDRA[10:0] selects a word; bit i lives at {ADDRA, i[2:0]}.
-// The procedural for loop exposes only a single write port,
-// matching the Vivado BRAM inference requirements.
+// Port A — 8-bit synchronous read/write or read-only.
 // ------------------------------
-integer i;
-
 generate
     if (PORT_A_WRITABLE) begin : port_a_read_write
         always @(posedge CLKA) begin
-            for (i = 0; i < 8; i = i + 1) begin
-                DOUTA[i] <= ram[{ADDRA, i[2:0]}];
-                if (WEA)
-                    ram[{ADDRA, i[2:0]}] <= DINA[i];
-            end
+            DOUTA <= ram[ADDRA];  // read-first: capture old value
+            if (WEA)
+                ram[ADDRA] <= DINA;
         end
     end else begin : port_a_read_only
-        always @(posedge CLKA) begin
-            for (i = 0; i < 8; i = i + 1)
-                DOUTA[i] <= ram[{ADDRA, i[2:0]}];
-        end
+        always @(posedge CLKA)
+            DOUTA <= ram[ADDRA];
     end
 endgenerate
 
 // ------------------------------
-// Port B — 1-bit synchronous (simple, one port)
+// Port B — 1-bit synchronous read/write or read-only.
 // ------------------------------
 generate
     if (PORT_B_WRITABLE) begin : port_b_read_write
         always @(posedge CLKB) begin
-            DOUTB          <= ram[ADDRB];
+            DOUTB[0] <= ram[addrb_word][addrb_bit];  // read-first: capture old value
             if (WEB)
-                ram[ADDRB] <= DINB[0];
+                ram[addrb_word][addrb_bit] <= DINB[0];
         end
     end else begin : port_b_read_only
         always @(posedge CLKB)
-            DOUTB <= ram[ADDRB];
+            DOUTB[0] <= ram[addrb_word][addrb_bit];
     end
 endgenerate
 

--- a/basil/firmware/modules/spi/blk_mem_gen_8_to_1_2k.v
+++ b/basil/firmware/modules/spi/blk_mem_gen_8_to_1_2k.v
@@ -4,33 +4,21 @@
  * SiLab, Institute of Physics, University of Bonn
  * ------------------------------------------------------------
  *
- * Asymmetric dual-port memory: 2048 x 8-bit (Port A) / 16384 x 1-bit (Port B).
- * Total capacity: 16,384 bits → intended to infer one 7-series RAMB18E1 in
- * block-RAM memory mode. See AMD/Xilinx UG473, 7 Series FPGAs Memory Resources:
- * https://docs.amd.com/v/u/en-US/ug473_7Series_Memory_Resources
+ * This is a 16,384-bit asymmetric true-dual-port synchronous RAM. Port A
+ * addresses 2048 8-bit words through ADDRA, DINA, DOUTA, and WEA. Port B
+ * addresses 16384 individual bits through ADDRB, DINB, DOUTB, and WEB.
+ * When one port reads and writes the same location on a clock edge, its output
+ * receives the previous value while the new value is stored. Access to the
+ * same bit from both independently clocked ports should be avoided.
  *
- * Replaces the legacy RAMB16_S1_S9 primitive (Spartan-3/Virtex-4 era),
- * which is unsupported in Vivado.
+ * The behavioral description follows the AMD UG901 asymmetric
+ * true-dual-port read-first inference template. The ram_style attribute asks
+ * Vivado to map it to a 7-series RAMB18E1, while the same RTL remains usable
+ * with Verilator and Icarus.
+ * https://docs.amd.com/r/en-US/2026.1/ug901-vivado-synthesis/True-Dual-Port-Asymmetric-RAM-Read-First-Verilog
  *
- * Inference strategy:
- *   Underlying array is 2048 × 8-bit. Port A accesses full bytes directly.
- *   Port B maps its 14-bit bit address to byte address ADDRB[13:3] and bit
- *   index ADDRB[2:0]. This keeps the memory declaration in a conventional
- *   byte-wide shape for Vivado inference while preserving the legacy 8-to-1
- *   asymmetric interface.
- *   (* ram_style = "block" *) attribute forces BRAM over distributed RAM.
- *
- * This is deliberately not the dedicated BRAM FIFO mode described in UG473.
- * Although the SPI data path is FIFO-like (bytes are played out serially),
- * spi_core owns the byte/bit addresses, repeat count, waits, and replay control.
- * A BRAM FIFO primitive would hide/destructively advance those pointers, while
- * this block must remain an addressable, replayable SPI pattern/readback memory.
- *
- * Port mapping (unchanged from original):
- *   Port A: 8-bit wide, 2048 deep  — ADDRA[10:0], DINA[7:0], DOUTA[7:0], WEA
- *   Port B: 1-bit wide, 16384 deep — ADDRB[13:0], DINB[0],   DOUTB[0],   WEB
- *
- * Read behaviour: read-first on both ports (consistent with legacy primitive).
+ * The RAMB18E1 primitive is documented in AMD UG953.
+ * https://docs.amd.com/r/en-US/ug953-vivado-7series-libraries/RAMB18E1
  * ------------------------------------------------------------
  */
 `ifndef BLK_MEM_GEN_8_TO_1_2K
@@ -40,73 +28,50 @@
 `default_nettype none
 
 
-module blk_mem_gen_8_to_1_2k #(
-    // Disable a port's write logic when its write enable is tied low.
-    // This avoids elaborating unused cross-clock RAM write paths.
-    parameter PORT_A_WRITABLE = 1,
-    parameter PORT_B_WRITABLE = 1
-) (
+module blk_mem_gen_8_to_1_2k (
     CLKA, CLKB, DOUTA, DOUTB, WEA, WEB, ADDRA, ADDRB, DINA, DINB
 );
 
 input  wire         CLKA;
 input  wire         CLKB;
 output reg  [7 : 0] DOUTA;
-output reg  [0 : 0] DOUTB;
-input  wire [0 : 0] WEA;
-input  wire [0 : 0] WEB;
+output reg          DOUTB;
+input  wire         WEA;
+input  wire         WEB;
 input  wire [10 : 0] ADDRA;
 input  wire [13 : 0] ADDRB;
 input  wire [7 : 0] DINA;
-input  wire [0 : 0] DINB;
+input  wire         DINB;
 
-// -------------------------------------------------------------------
-// Underlying array: 2048 × 8-bit = 16,384 bits.
-// Port B's 14-bit address is split into byte address and bit index.
-// -------------------------------------------------------------------
-
-// The generic module supports two writable ports for legacy compatibility, but
-// current SPI instances enable only one write port per memory. Verilator cannot
-// prove that for the default parameterization and reports MULTIDRIVEN.
+// Both ports can read and write. Current SPI instances tie one write enable low,
+// but retaining the exact TDP template keeps the memory reusable and inferable.
+// Static lint cannot prove that the two SPI instances have only one active writer.
 // verilator lint_off MULTIDRIVEN
 (* ram_style = "block" *)
-reg [7:0] ram [0:2047];
+reg ram [0:16383];
 // verilator lint_on MULTIDRIVEN
 
-wire [10:0] addrb_word = ADDRB[13:3];
-wire [2:0] addrb_bit = ADDRB[2:0];
+// Narrow 1-bit port.
+always @(posedge CLKB) begin
+    DOUTB <= ram[ADDRB];
+    if (WEB)
+        ram[ADDRB] <= DINB;
+end
 
-// ------------------------------
-// Port A — 8-bit synchronous read/write or read-only.
-// ------------------------------
-generate
-    if (PORT_A_WRITABLE) begin : port_a_read_write
-        always @(posedge CLKA) begin
-            DOUTA <= ram[ADDRA];  // read-first: capture old value
-            if (WEA)
-                ram[ADDRA] <= DINA;
-        end
-    end else begin : port_a_read_only
-        always @(posedge CLKA)
-            DOUTA <= ram[ADDRA];
-    end
-endgenerate
+// Wide 8-bit port. Concatenating the byte address and fixed loop index is the
+// UG901 asymmetric-port form. Nonblocking assignments provide read-first
+// behavior when this port writes.
+always @(posedge CLKA) begin : port_a
+    integer bit_index;
+    reg [2:0] lsb_address;
 
-// ------------------------------
-// Port B — 1-bit synchronous read/write or read-only.
-// ------------------------------
-generate
-    if (PORT_B_WRITABLE) begin : port_b_read_write
-        always @(posedge CLKB) begin
-            DOUTB[0] <= ram[addrb_word][addrb_bit];  // read-first: capture old value
-            if (WEB)
-                ram[addrb_word][addrb_bit] <= DINB[0];
-        end
-    end else begin : port_b_read_only
-        always @(posedge CLKB)
-            DOUTB[0] <= ram[addrb_word][addrb_bit];
+    for (bit_index = 0; bit_index < 8; bit_index = bit_index + 1) begin
+        lsb_address = bit_index[2:0];
+        DOUTA[bit_index] <= ram[{ADDRA, lsb_address}];
+        if (WEA)
+            ram[{ADDRA, lsb_address}] <= DINA[bit_index];
     end
-endgenerate
+end
 
 endmodule
 

--- a/basil/firmware/modules/spi/spi_core.v
+++ b/basil/firmware/modules/spi/spi_core.v
@@ -50,15 +50,15 @@ module spi_core #(
 
   assign RST = BUS_RST || SOFT_RST;
 
-  localparam DEF_BIT_OUT = 8 * MEM_BYTES;
+  localparam DefBitOut = 8 * MEM_BYTES;
 
   always @(posedge BUS_CLK) begin
     if (RST) begin
       status_regs[0]  <= 0;
       status_regs[1]  <= 0;
       status_regs[2]  <= 0;
-      status_regs[3]  <= DEF_BIT_OUT[7:0];  //bits
-      status_regs[4]  <= DEF_BIT_OUT[15:8];  //bits
+      status_regs[3]  <= DefBitOut[7:0];  //bits
+      status_regs[4]  <= DefBitOut[15:8];  //bits
       status_regs[5]  <= 4;  //wait
       status_regs[6]  <= 0;  //wait
       status_regs[7]  <= 0;  //wait
@@ -151,10 +151,7 @@ module spi_core #(
   // at the system level, but intentionally implemented as addressable BRAM
   // memory (not RAMB18/FIFO18 FIFO mode; see UG473) because this state machine
   // owns bit addresses, waits, repeats, and replay of the same programmed data.
-  blk_mem_gen_8_to_1_2k #(
-      .PORT_A_WRITABLE(1),
-      .PORT_B_WRITABLE(0)
-  ) memout (
+  blk_mem_gen_8_to_1_2k memout (
       .CLKA (BUS_CLK),
       .CLKB (SPI_CLK),
       .DOUTA(BUS_IN_MEM_IB),
@@ -178,10 +175,7 @@ module spi_core #(
   // bit at a time, and the bus reads the same storage back as addressable bytes.
   // As above, this must remain RAM-style storage rather than dedicated BRAM FIFO
   // mode so spi_core can control the exact bit addresses and transaction timing.
-  blk_mem_gen_8_to_1_2k #(
-      .PORT_A_WRITABLE(0),
-      .PORT_B_WRITABLE(1)
-  ) memin (
+  blk_mem_gen_8_to_1_2k memin (
       .CLKA (BUS_CLK),
       .CLKB (SPI_CLK),
       .DOUTA(BUS_OUT_MEM_IB),

--- a/basil/firmware/modules/spi/spi_core.v
+++ b/basil/firmware/modules/spi/spi_core.v
@@ -116,6 +116,7 @@ module spi_core #(
     end
   end
 
+
   always @(*) begin
     if (PREV_BUS_ADD < 16) BUS_DATA_OUT = BUS_DATA_OUT_REG;
     else if (PREV_BUS_ADD < 16 + MEM_BYTES) BUS_DATA_OUT = BUS_IN_MEM;
@@ -145,6 +146,11 @@ module spi_core #(
 
   wire SDI_MEM;
 
+  // SPI transmit pattern memory. The bus writes addressable 8-bit bytes and
+  // the SPI clock domain reads them as a 1-bit serial stream. This is FIFO-like
+  // at the system level, but intentionally implemented as addressable BRAM
+  // memory (not RAMB18/FIFO18 FIFO mode; see UG473) because this state machine
+  // owns bit addresses, waits, repeats, and replay of the same programmed data.
   blk_mem_gen_8_to_1_2k #(
       .PORT_A_WRITABLE(1),
       .PORT_B_WRITABLE(0)
@@ -168,6 +174,10 @@ module spi_core #(
   assign ADDRB_MIN = out_bit_cnt - 1;
   reg SEN_INT;
 
+  // SPI receive/readback memory. The SPI clock domain writes one captured SDO
+  // bit at a time, and the bus reads the same storage back as addressable bytes.
+  // As above, this must remain RAM-style storage rather than dedicated BRAM FIFO
+  // mode so spi_core can control the exact bit addresses and transaction timing.
   blk_mem_gen_8_to_1_2k #(
       .PORT_A_WRITABLE(0),
       .PORT_B_WRITABLE(1)


### PR DESCRIPTION
In pull request #272, I replaced the explicit outdated instance of `RAMB16_S1_S9` with an attempt to use the `ram_style` attribute, allowing a behavioral description during simulation that would then map to a RAMB18E1 during Vivado synthesis.

Turns out that I did this wrong, and that ram_style = "block" alone cannot make an arbitrary memory description infer BRAM. Since the usage of the RAM here is a little fancy, with different widths for the two ports, it was actually just mapping to LUT RAM.

I have now read the [Vivado UG901 document](https://docs.amd.com/r/en-US/2026.1/ug901-vivado-synthesis/Dual-Port-Asymmetric-RAM-When-Read-is-Wider-than-Write-Verilog), though, which explains how to properly use this attribute together with a supported asymmetric RAM inference template. 

This fix changes the behavioral description to follow that template. The memory is described as a 16,384 x 1-bit array. The narrow port accesses individual bits directly, while the wide port uses a fixed loop to read or write eight consecutive bits as one byte. Verilator and Icarus can simulate it behaviorally, while Vivado recognizes the same description as block RAM (each of the two instances in `spi_core` maps one `RAMB18E1`).

In the synthesis report, one now sees the following:

```
Block RAM: Final Mapping Report
+-----------------------+------------+------------------------+---+---+------------------------+---+---+------------------+--------+--------+
|Module Name            | RTL Object | PORT A (Depth x Width) | W | R | PORT B (Depth x Width) | W | R | Ports driving FF | RAMB18 | RAMB36 | 
+-----------------------+------------+------------------------+---+---+------------------------+---+---+------------------+--------+--------+
|blk_mem_gen_8_to_1_2k: | ram_reg    | 16 K x 1(READ_FIRST)   | W | R | 2 K x 8(READ_FIRST)    | W | R | Port A and B     | 1      | 0      | 
|blk_mem_gen_8_to_1_2k: | ram_reg    | 16 K x 1(READ_FIRST)   | W | R | 2 K x 8(READ_FIRST)    | W | R | Port A and B     | 1      | 0      | 
+-----------------------+------------+------------------------+---+---+------------------------+---+---+------------------+--------+--------+
```


