### PR TITLE
Banish the ghost of codecov

### DIFF
--- a/.github/workflows/regression-tests.yml
+++ b/.github/workflows/regression-tests.yml
@@ -22,7 +22,7 @@ jobs:
         python-version: "3.12"
     - uses: pre-commit/action@v3.0.1
       env:
-        SKIP: diff-coverage # Run all normal formatting hooks in CI, but skip the local diff-coverage hook because the coverage job handles it separately.
+        SKIP: coverage # Run all normal formatting hooks in CI, but skip the local coverage hook because the coverage job handles it separately.
 
   tests:
 

--- a/.github/workflows/regression-tests.yml
+++ b/.github/workflows/regression-tests.yml
@@ -42,6 +42,7 @@ jobs:
 
           - sim: icarus
             python-version: '3.13'
+            coverage: true
 
           - sim: verilator
             sim-version: 5.044
@@ -71,7 +72,13 @@ jobs:
     - name: Install Python dependencies
       shell: bash -l {0}
       run: |
-        pip install pyvisa pyvisa-sim pytest coverage coveralls pytest-cov cocotb>=2 cocotb-bus
+        pip install pyvisa pyvisa-sim pytest cocotb>=2 cocotb-bus
+
+    - name: Install coverage dependency
+      if: matrix.coverage
+      shell: bash -l {0}
+      run: |
+        pip install pytest-cov
 
     - name: Install basil
       shell: bash -l {0}
@@ -79,13 +86,14 @@ jobs:
         pip install -e .
 
     - name: Test
+      if: ${{ !matrix.coverage }}
+      shell: bash -l {0}
+      run: |
+        pytest ${{matrix.pytest-marker}} tests/test_*.py examples/*/*/test_*.py
+
+    - name: Test with coverage
+      if: matrix.coverage
       shell: bash -l {0}
       run: |
         pytest ${{matrix.pytest-marker}} --cov=basil tests/test_*.py examples/*/*/test_*.py
-
-    - name: Upload to codecov
-      shell: bash -l {0}
-      run: |
-        curl -Os https://uploader.codecov.io/latest/linux/codecov
-        chmod +x codecov
-        ./codecov -t ${CODECOV_TOKEN}
+        coverage report --format=total | awk '{print "### Test coverage: " $1 "%"}' >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/regression-tests.yml
+++ b/.github/workflows/regression-tests.yml
@@ -59,6 +59,8 @@ jobs:
 
     steps:
     - uses: actions/checkout@v6
+      with:
+        fetch-depth: ${{ matrix.coverage && '0' || '1' }}
     - name: Set up miniforge ${{matrix.python-version}}
       uses: conda-incubator/setup-miniconda@v3
       with:
@@ -107,14 +109,6 @@ jobs:
           tests/test_*.py examples/*/*/test_*.py
         coverage xml -o coverage.xml
         coverage report --format=total | awk '{print "### Test coverage: " $1 "%"}' >> "$GITHUB_STEP_SUMMARY"
-
-    - name: Fetch pull request base
-      if: matrix.coverage && github.event_name == 'pull_request'
-      env:
-        BASE_REF: ${{github.base_ref}}
-      run: |
-        git fetch --no-tags --depth=1 origin \
-          "+refs/heads/${BASE_REF}:refs/remotes/origin/${BASE_REF}"
 
     - name: Create differential coverage report
       if: matrix.coverage && github.event_name == 'pull_request'

--- a/.github/workflows/regression-tests.yml
+++ b/.github/workflows/regression-tests.yml
@@ -86,7 +86,7 @@ jobs:
       if: matrix.coverage
       shell: bash -l {0}
       run: |
-        pip install pytest-cov diff-cover
+        pip install coverage diff-cover
 
     - name: Install basil
       shell: bash -l {0}
@@ -103,10 +103,9 @@ jobs:
       if: matrix.coverage
       shell: bash -l {0}
       run: |
-        pytest ${{matrix.pytest-marker}} \
-          --cov=basil \
-          --cov-report=xml:coverage.xml \
+        coverage run --source=basil -m pytest ${{matrix.pytest-marker}} \
           tests/test_*.py examples/*/*/test_*.py
+        coverage xml -o coverage.xml
         coverage report --format=total | awk '{print "### Test coverage: " $1 "%"}' >> "$GITHUB_STEP_SUMMARY"
 
     - name: Fetch pull request base

--- a/.github/workflows/regression-tests.yml
+++ b/.github/workflows/regression-tests.yml
@@ -8,6 +8,9 @@ on:
     branches:
     - master
 
+permissions:
+  contents: read
+
 jobs:
 
   pre-commit:
@@ -18,11 +21,16 @@ jobs:
       with:
         python-version: "3.12"
     - uses: pre-commit/action@v3.0.1
+      env:
+        SKIP: diff-coverage # Run all normal formatting hooks in CI, but skip the local diff-coverage hook because the coverage job handles it separately.
 
   tests:
 
     name: Python ${{matrix.python-version}} | ${{matrix.sim}}
     runs-on: ubuntu-24.04
+    permissions:
+      contents: read
+      checks: write
     env:
       SIM: ${{matrix.sim}}
 
@@ -78,7 +86,7 @@ jobs:
       if: matrix.coverage
       shell: bash -l {0}
       run: |
-        pip install pytest-cov
+        pip install pytest-cov diff-cover
 
     - name: Install basil
       shell: bash -l {0}
@@ -95,5 +103,49 @@ jobs:
       if: matrix.coverage
       shell: bash -l {0}
       run: |
-        pytest ${{matrix.pytest-marker}} --cov=basil tests/test_*.py examples/*/*/test_*.py
+        pytest ${{matrix.pytest-marker}} \
+          --cov=basil \
+          --cov-report=xml:coverage.xml \
+          tests/test_*.py examples/*/*/test_*.py
         coverage report --format=total | awk '{print "### Test coverage: " $1 "%"}' >> "$GITHUB_STEP_SUMMARY"
+
+    - name: Fetch pull request base
+      if: matrix.coverage && github.event_name == 'pull_request'
+      env:
+        BASE_REF: ${{github.base_ref}}
+      run: |
+        git fetch --no-tags --depth=1 origin \
+          "+refs/heads/${BASE_REF}:refs/remotes/origin/${BASE_REF}"
+
+    - name: Create differential coverage report
+      if: matrix.coverage && github.event_name == 'pull_request'
+      env:
+        BASE_REF: ${{github.base_ref}}
+      shell: bash -l {0}
+      run: |
+        diff-cover coverage.xml \
+          --compare-branch="origin/${BASE_REF}" \
+          --format=markdown:diff-cover.md
+        cat diff-cover.md >> "$GITHUB_STEP_SUMMARY"
+
+    - name: Publish differential coverage check
+      if: >-
+        matrix.coverage &&
+        github.event_name == 'pull_request' &&
+        github.event.pull_request.head.repo.full_name == github.repository
+      continue-on-error: true
+      env:
+        GH_TOKEN: ${{github.token}}
+        HEAD_SHA: ${{github.event.pull_request.head.sha}}
+      run: |
+        gh api --method POST \
+          --header "Accept: application/vnd.github+json" \
+          --header "X-GitHub-Api-Version: 2022-11-28" \
+          "repos/${GITHUB_REPOSITORY}/check-runs" \
+          --raw-field name="Coverage (informational)" \
+          --raw-field head_sha="$HEAD_SHA" \
+          --raw-field status=completed \
+          --raw-field conclusion=neutral \
+          --raw-field "output[title]=Differential coverage" \
+          --field "output[summary]=@diff-cover.md" \
+          --silent

--- a/.gitignore
+++ b/.gitignore
@@ -41,6 +41,10 @@ Makefile
 *.out
 examples/lx9/device/src/SiTCP
 
+# Test coverage
+.coverage
+coverage.xml
+
 # PyDev files
 .project
 .pydevproject

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -17,13 +17,14 @@ repos:
     -   id: trailing-whitespace
   - repo: local
     hooks:
-      - id: diff-coverage
-        name: Differential test coverage
+      - id: coverage
+        name: Coverage
         entry: >-
           bash -c 'SIM=icarus coverage run
           --source=basil -m pytest
+          -q --disable-warnings
           tests/test_*.py examples/*/*/test_*.py
-          && coverage xml -o coverage.xml
+          && coverage xml -q -o coverage.xml
           && diff-cover coverage.xml
           --compare-branch=origin/master
           --show-uncovered'

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -20,10 +20,10 @@ repos:
       - id: diff-coverage
         name: Differential test coverage
         entry: >-
-          bash -c 'SIM=icarus pytest
-          --cov=basil
-          --cov-report=xml:coverage.xml
+          bash -c 'SIM=icarus coverage run
+          --source=basil -m pytest
           tests/test_*.py examples/*/*/test_*.py
+          && coverage xml -o coverage.xml
           && diff-cover coverage.xml
           --compare-branch=origin/master
           --show-uncovered'

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -15,3 +15,20 @@ repos:
     hooks:
     -   id: end-of-file-fixer
     -   id: trailing-whitespace
+  - repo: local
+    hooks:
+      - id: diff-coverage
+        name: Differential test coverage
+        entry: >-
+          bash -c 'SIM=icarus pytest
+          --cov=basil
+          --cov-report=xml:coverage.xml
+          tests/test_*.py examples/*/*/test_*.py
+          && diff-cover coverage.xml
+          --compare-branch=origin/master
+          --show-uncovered'
+        language: system
+        pass_filenames: false
+        verbose: true
+        files: ^(basil/|tests/|examples/).*\.py$
+        stages: [pre-commit]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,7 +38,6 @@ hw = ["pyserial", "PyVISA"]
 
 test = [
     "coverage",
-    "coveralls",
     "cocotb>=2.0.1",
     "cocotb-bus>=0.3.0",
     "cocotb-test>=0.2.6",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,6 +41,7 @@ test = [
     "cocotb>=2.0.1",
     "cocotb-bus>=0.3.0",
     "cocotb-test>=0.2.6",
+    "diff-cover",
     "pytest>=9.0.3",
     "pytest-cov",
     "PyVISA",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,7 +43,6 @@ test = [
     "cocotb-test>=0.2.6",
     "diff-cover",
     "pytest>=9.0.3",
-    "pytest-cov",
     "PyVISA",
     "pyvisa-sim",
 ]


### PR DESCRIPTION
I looked into these randomly appearing Codecov bot messages, and it turns out the integration has actually been active in this repository since 2020 ([it was added in this commit](https://github.com/SiLab-Bonn/basil/commit/389f4f74d4f1ddd271301660c80ae02807fea844)). It has occasionally worked since then, for example, it commented on [PR #251](https://github.com/SiLab-Bonn/basil/pull/251#issuecomment-3744820848), but most pull requests never receive a report.

The integration is configured in `.github/workflows/regression-tests.yml`. Because we do not have a `CODECOV_TOKEN` configured, it uses Codecov's legacy tokenless upload method. According to [the docs](https://docs.codecov.com/docs/codecov-tokens#legacy-upload-methods): "This method shares a global rate limit with other users" and is documented as unreliable, which explains why the integration only works intermittently.

So yeah... rather than re-setting up and maintaining another external account and access token for an unreliable service, this replaces Codecov with a simple coverage report produced directly by GitHub Actions.

Thoughts?
